### PR TITLE
Bump org.assertj:assertj-core from 3.26.3 to 3.27.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     // Library versions that Dependabot will monitor (in alphabetical order)
     // See also gradle/libs.versions.toml for manually maintained dependencies and Gradle plugins
     archUnitVersion = "0.23.1"
-    assertjVersion = "3.26.3"
+    assertjVersion = "3.27.3"
     awaitilityVersion = "4.2.2"
     blockhoundVersion = "1.0.10.RELEASE"
     byteBuddyVersion = "1.15.4"

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxOnAssemblyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,7 +230,8 @@ class FluxOnAssemblyTest {
 				assertThat(t)
 					.matches(Exceptions::isRetryExhausted, "isRetryExhausted")
 					.hasMessage("Retries exhausted: 3/3")
-					.hasCauseReference(reusedException);
+					.cause()
+					.isSameAs(reusedException);
 				assertThat(Arrays.asList(t.getCause().getSuppressed()))
 					.as("backtrace as suppressed on the cause")
 					.hasSize(1)
@@ -258,7 +259,8 @@ class FluxOnAssemblyTest {
 				assertThat(t)
 					.matches(Exceptions::isRetryExhausted, "isRetryExhausted")
 					.hasMessage("Retries exhausted: 2/2")
-					.hasCauseReference(reusedException);
+					.cause()
+					.isSameAs(reusedException);
 				assertThat(Arrays.asList(t.getCause().getSuppressed()))
 					.as("backtrace as suppressed on the cause")
 					.hasSize(1)


### PR DESCRIPTION
Replaced deprecated API usage.

Supersedes #3968