### PR TITLE
Interrupt VirtualThread task only from other Thread

### DIFF
--- a/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
+++ b/reactor-core/src/main/java21/reactor/core/scheduler/BoundedElasticThreadPerTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1114,7 +1114,9 @@ final class BoundedElasticThreadPerTaskScheduler
 				if (hasFuture(previousState)) {
 					this.scheduledFuture.cancel(true);
 				}
-				this.carrier.interrupt();
+				if (Thread.currentThread() != this.carrier) {
+					this.carrier.interrupt();
+				}
 				return;
 			}
 


### PR DESCRIPTION
When `BoundedElasticScheduler` processes a task, the task can be disposed. In the regular case the Thread executing the task will only be interrupted when the disposing Thread is different.

With the Virtual Thread-based implementation this behaviour should be similar. Since it was not, this change aligns the new implementation to be similar in that regard.

Fixes #3948