### PR TITLE
Refactor mono wrap method

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -5439,7 +5439,6 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		return shouldWrap ? ContextPropagation.monoRestoreThreadLocals(target) : target;
 	}
 
-	@SuppressWarnings("unchecked")
 	private static <T> Mono<T> createMonoSource(Publisher<T> source, boolean enforceMonoContract) {
 		if (enforceMonoContract) {
 			return source instanceof Flux ? new MonoNext<>((Flux<T>) source) : new MonoFromPublisher<>(source);

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -5427,7 +5427,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		}
 
 		if (source instanceof Flux && source instanceof Callable) {
-			return Flux.wrapToMono((Callable<T>) source);
+			@SuppressWarnings("unchecked")
+			Callable<T> callable = (Callable<T>) source;
+			return Flux.wrapToMono(callable);
 		}
 
 		Mono<T> target = createMonoSource(source, enforceMonoContract);

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -5411,6 +5411,8 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a wrapped {@link Mono}
 	 */
 	static <T> Mono<T> wrap(Publisher<T> source, boolean enforceMonoContract) {
+		//some sources can be considered already assembled monos
+		//all conversion methods (from, fromDirect, wrap) must accommodate for this
 		boolean shouldWrap = ContextPropagationSupport.shouldWrapPublisher(source);
 
 		if (source instanceof Mono) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -596,12 +596,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 			Mono<I> extracted = (Mono<I>) wrapper.source;
 			boolean shouldWrapExtracted =
 					ContextPropagationSupport.shouldWrapPublisher(extracted);
-			if (!shouldWrapExtracted) {
-				return extracted;
-			} else {
-				// Skip assembly hook
-				return wrap(extracted, false);
-			}
+			return shouldWrapExtracted ? wrap(extracted, false) : extracted;
 		}
 
 		//we delegate to `wrap` and apply assembly hooks


### PR DESCRIPTION
Description:
This refactoring improves the maintainability and readability of the Mono.wrap method through the following changes:

1. Extract Mono source creation logic into a separate method (createMonoSource)
   - Reduces cognitive complexity of the main wrap method
   - Makes the source creation logic more focused and easier to maintain

2. Simplify conditional logic using ternary operators
   - Reduces nesting levels in the code
   - Makes the flow control more straightforward

3. Improve type handling consistency
   - Refined type casting structure following existing patterns
   - Maintained consistent use of SuppressWarnings annotations in line with the codebase's existing conventions

The changes maintain the exact same functionality while making the code structure clearer and more maintainable.