### PR TITLE
refector when methods(when, whenDelayError)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1089,13 +1089,11 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a {@link Mono}.
 	 */
 	public static Mono<Void> when(Publisher<?>... sources) {
-		if (sources.length == 0) {
-			return empty();
-		}
-		if (sources.length == 1) {
-			return empty(sources[0]);
-		}
-		return onAssembly(new MonoWhen(false, sources));
+		return switch (sources.length) {
+			case 0 -> empty();
+			case 1 -> empty(sources[0]);
+			default -> onAssembly(new MonoWhen(false, sources));
+		};
 	}
 
 
@@ -1148,13 +1146,11 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a {@link Mono}.
 	 */
 	public static Mono<Void> whenDelayError(Publisher<?>... sources) {
-		if (sources.length == 0) {
-			return empty();
-		}
-		if (sources.length == 1) {
-			return empty(sources[0]);
-		}
-		return onAssembly(new MonoWhen(true, sources));
+		return switch (sources.length) {
+			case 0 -> empty();
+			case 1 -> empty(sources[0]);
+			default -> onAssembly(new MonoWhen(true, sources));
+		};
 	}
 
 	/**


### PR DESCRIPTION
Refactored an if-else statement into a ternary return to improve readability and conciseness.

This change simplifies the return logic by replacing an explicit if-else with a ternary operator. However, I am aware that this syntax is available from Java 14 onwards. I checked git blame and noticed that this code has not been modified for quite some time, so I took the opportunity to refactor it.

If this change is acceptable, please feel free to leave a comment.

Effect points: when(Publisher<?>... sources) , whenDelayError(Publisher<?>... sources)
