### PR TITLE
Eliminate most compiler warnings

### DIFF
--- a/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
+++ b/reactor-core-micrometer/src/main/java/reactor/core/observability/micrometer/TimedScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ final class TimedScheduler implements Scheduler {
 		delegate.dispose();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void start() {
 		delegate.start();

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxBufferTimeoutStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxBufferTimeoutStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -468,6 +468,7 @@ public class FluxBufferTimeoutStressTest {
 		throw new IllegalStateException(msg + "\n" + fastLogger);
 	}
 
+	@SafeVarargs
 	private static boolean allValuesHandled(FastLogger logger, int range, List<Object> discarded, List<List<Long>>... delivered) {
 		if (delivered.length == 0) {
 			return false;

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/FluxSwitchMapStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import org.openjdk.jcstress.infra.results.I_Result;
 import org.openjdk.jcstress.infra.results.JI_Result;
 import org.openjdk.jcstress.infra.results.JJJJJJJ_Result;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Exceptions;
 import reactor.core.publisher.FluxSwitchMapNoPrefetch.SwitchMapMain;
@@ -37,13 +39,16 @@ import reactor.test.publisher.TestPublisher;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class FluxSwitchMapStressTest {
+
+	private static final CoreSubscriber<Object> DUMMY_SUBSCRIBER = Operators.emptySubscriber();
 
 	final FastLogger fastLogger = new FastLogger(this.getClass().getSimpleName());
 	final StateLogger logger = new StateLogger(fastLogger);
 
 	final StressSubscriber<Object> stressSubscriber = new StressSubscriber<>(0);
-	final StressSubscription stressSubscription = new StressSubscription(null);
+	final StressSubscription stressSubscription = new StressSubscription(DUMMY_SUBSCRIBER);
 
 	final SwitchMapMain<Object, Object> switchMapMain =
 			new SwitchMapMain<>(stressSubscriber, this::handle, logger);
@@ -149,7 +154,7 @@ public abstract class FluxSwitchMapStressTest {
 		Publisher<Object> handle(Object value) {
 			return s -> {
 				final StressSubscription subscription =
-						new StressSubscription<>((CoreSubscriber) s);
+						new StressSubscription<>((CoreSubscriber<?>) s);
 				this.subscription = subscription;
 				s.onSubscribe(subscription);
 			};

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayElementStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayElementStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
+@SuppressWarnings("unchecked")
 public abstract class MonoDelayElementStressTest {
 
 	@JCStressTest
@@ -51,7 +52,9 @@ public abstract class MonoDelayElementStressTest {
 			monoDelay = new MonoDelayElement<>(Mono.never(), 0L,
 					TimeUnit.MILLISECONDS,
 					virtualTimeScheduler);
-			monoDelay.doOnSubscribe(s -> subscription = ((MonoDelayElement.DelayElementSubscriber) s)).subscribe(subscriber);
+
+			monoDelay.doOnSubscribe(s -> subscription =
+					((MonoDelayElement.DelayElementSubscriber<Object>) s)).subscribe(subscriber);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayElementStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/MonoDelayElementStressTest.java
@@ -28,7 +28,6 @@ import reactor.test.scheduler.VirtualTimeScheduler;
 
 import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
 
-@SuppressWarnings("unchecked")
 public abstract class MonoDelayElementStressTest {
 
 	@JCStressTest
@@ -53,8 +52,12 @@ public abstract class MonoDelayElementStressTest {
 					TimeUnit.MILLISECONDS,
 					virtualTimeScheduler);
 
-			monoDelay.doOnSubscribe(s -> subscription =
-					((MonoDelayElement.DelayElementSubscriber<Object>) s)).subscribe(subscriber);
+			monoDelay.doOnSubscribe(s -> {
+				@SuppressWarnings("unchecked")
+				MonoDelayElement.DelayElementSubscriber<Object> elementSubscriber =
+						(MonoDelayElement.DelayElementSubscriber<Object>) s;
+				subscription = elementSubscriber;
+			}).subscribe(subscriber);
 		}
 
 		@Actor

--- a/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscription.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/StressSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ public class StressSubscription<T> implements Subscription {
 	final CoreSubscriber<? super T> actual;
 
 	volatile long requested;
+
+	@SuppressWarnings("rawtypes")
 	static final AtomicLongFieldUpdater<StressSubscription> REQUESTED =
 		AtomicLongFieldUpdater.newUpdater(StressSubscription.class, "requested");
 

--- a/reactor-core/src/jcstress/java/reactor/core/scheduler/BasicSchedulersStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/scheduler/BasicSchedulersStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import reactor.core.Disposable;
 
 public abstract class BasicSchedulersStressTest {
 
+	@SuppressWarnings("deprecation")
 	private static void restart(Scheduler scheduler) {
 		scheduler.disposeGracefully().block(Duration.ofMillis(500));
 		// TODO: in 3.6.x: remove restart capability and this validation

--- a/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ContextPropagation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ final class ContextPropagation {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "deprecation"})
 	private static <V> Map<Object, Object> setThreadLocal(Object key, @Nullable V value,
 			ThreadLocalAccessor<?> accessor, @Nullable Map<Object, Object> previousValues) {
 
@@ -115,6 +115,7 @@ final class ContextPropagation {
 		return previousValues;
 	}
 
+	@SuppressWarnings("deprecation")
 	static ContextSnapshot captureThreadLocals() {
 		if (ContextPropagationSupport.isContextPropagation103OnClasspath) {
 			return globalContextSnapshotFactory.captureAll();
@@ -163,6 +164,7 @@ final class ContextPropagation {
 	 * @param <T> type of handled values
 	 * @param <R> the transformed type
 	 */
+	@SuppressWarnings({"deprecation", "try"})
 	static <T, R> BiConsumer<T, SynchronousSink<R>> contextRestoreForHandle(BiConsumer<T, SynchronousSink<R>> handler, Supplier<Context> contextSupplier) {
 		if (ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators()) {
 			final Context ctx = contextSupplier.get();
@@ -179,7 +181,8 @@ final class ContextPropagation {
 			}
 			else {
 				return (v, sink) -> {
-					try (ContextSnapshot.Scope ignored = ContextSnapshot.setAllThreadLocalsFrom(ctx)) {
+					try (ContextSnapshot.Scope ignored =
+							     ContextSnapshot.setAllThreadLocalsFrom(ctx)) {
 						handler.accept(v, sink);
 					}
 				};
@@ -234,11 +237,13 @@ final class ContextPropagation {
 			this.context = context;
 		}
 
+		@SuppressWarnings("deprecation")
 		ContextSnapshot.Scope restoreThreadLocals() {
 			return ContextSnapshot.setAllThreadLocalsFrom(this.context);
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doFirst() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFirst();
@@ -246,6 +251,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doFinally(SignalType terminationType) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doFinally(terminationType);
@@ -253,6 +259,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnSubscription() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnSubscription();
@@ -260,6 +267,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnFusion(int negotiatedFusion) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnFusion(negotiatedFusion);
@@ -267,6 +275,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnRequest(long requested) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnRequest(requested);
@@ -274,6 +283,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnCancel() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnCancel();
@@ -281,6 +291,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnNext(T value) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnNext(value);
@@ -288,6 +299,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnComplete();
@@ -295,6 +307,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnError(error);
@@ -302,6 +315,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doAfterComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterComplete();
@@ -309,6 +323,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doAfterError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doAfterError(error);
@@ -316,6 +331,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnMalformedOnNext(T value) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnNext(value);
@@ -323,6 +339,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnMalformedOnError(Throwable error) throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnError(error);
@@ -330,6 +347,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void doOnMalformedOnComplete() throws Throwable {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.doOnMalformedOnComplete();
@@ -337,6 +355,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final void handleListenerError(Throwable listenerError) {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				original.handleListenerError(listenerError);
@@ -344,6 +363,7 @@ final class ContextPropagation {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public final Context addToContext(Context originalContext) {
 			try (ContextSnapshot.Scope ignored = restoreThreadLocals()) {
 				return original.addToContext(originalContext);
@@ -492,7 +512,7 @@ final class ContextPropagation {
 			}
 		}
 
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "deprecation"})
 		private <V> void resetThreadLocalValue(ThreadLocalAccessor<?> accessor, @Nullable V previousValue) {
 			if (previousValue != null) {
 				((ThreadLocalAccessor<V>) accessor).restore(previousValue);
@@ -530,7 +550,7 @@ final class ContextPropagation {
 			}
 		}
 
-		@SuppressWarnings("unchecked")
+		@SuppressWarnings({"unchecked", "deprecation"})
 		private <V> void resetThreadLocalValue(ThreadLocalAccessor<?> accessor, @Nullable V previousValue) {
 			if (previousValue != null) {
 				((ThreadLocalAccessor<V>) accessor).setValue(previousValue);

--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10799,6 +10799,7 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	public final <T2, V> Flux<V> zipWith(Publisher<? extends T2> source2,
 			final BiFunction<? super T, ? super T2, ? extends V> combinator) {
 		if (this instanceof FluxZip) {
+			@SuppressWarnings("unchecked")
 			FluxZip<T, V> o = (FluxZip<T, V>) this;
 			Flux<V> result = o.zipAdditionalSource(source2, combinator);
 			if (result != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -140,7 +140,6 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				if (!(s instanceof QueueSubscription)) {
@@ -148,8 +147,11 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 					return;
 				}
 				this.s = s;
-				//noinspection unchecked
-				this.qs = (QueueSubscription<T>) s;
+
+				@SuppressWarnings("unchecked")
+				QueueSubscription<T> qs = (QueueSubscription<T>) s;
+
+				this.qs = qs;
 
 				try {
 					listener.doOnSubscription();

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapFuseable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,6 +140,7 @@ final class FluxTapFuseable<T, STATE> extends InternalFluxOperator<T, T> impleme
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				if (!(s instanceof QueueSubscription)) {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTapRestoringThreadLocals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 	}
 
 	@Override
+	@SuppressWarnings("try")
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.
@@ -141,6 +142,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		 * @param listenerError the exception thrown from a handler method before the subscription was set
 		 * @param toCancel      the {@link Subscription} that was prepared but not sent downstream
 		 */
+		@SuppressWarnings("try")
 		protected void handleListenerErrorPreSubscription(Throwable listenerError, Subscription toCancel) {
 			toCancel.cancel();
 			listener.handleListenerError(listenerError);
@@ -156,6 +158,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		 *
 		 * @param listenerError the exception thrown from a handler method
 		 */
+		@SuppressWarnings("try")
 		protected void handleListenerErrorAndTerminate(Throwable listenerError) {
 			s.cancel();
 			listener.handleListenerError(listenerError);
@@ -173,6 +176,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		 * @param listenerError the exception thrown from a handler method
 		 * @param originalError the exception that was about to occur when handler was invoked
 		 */
+		@SuppressWarnings("try")
 		protected void handleListenerErrorMultipleAndTerminate(Throwable listenerError, Throwable originalError) {
 			s.cancel();
 			listener.handleListenerError(listenerError);
@@ -195,6 +199,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void onSubscribe(Subscription s) {
 			if (Operators.validate(this.s, s)) {
 				this.s = s;
@@ -213,6 +218,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void onNext(T t) {
 			if (done) {
 				try {
@@ -237,6 +243,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public boolean tryOnNext(T t) {
 			try (ContextSnapshot.Scope ignored =
 						 ContextPropagation.setThreadLocals(actual.currentContext())) {
@@ -257,6 +264,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void onError(Throwable t) {
 			if (done) {
 				try {
@@ -292,6 +300,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void onComplete() {
 			if (done) {
 				try {
@@ -324,6 +333,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void request(long n) {
 			try (ContextSnapshot.Scope ignored =
 						 ContextPropagation.setThreadLocals(this.context)) {
@@ -340,6 +350,7 @@ final class FluxTapRestoringThreadLocals<T, STATE> extends FluxOperator<T, T> {
 		}
 
 		@Override
+		@SuppressWarnings("try")
 		public void cancel() {
 			try (ContextSnapshot.Scope ignored =
 						 ContextPropagation.setThreadLocals(this.context)) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -562,7 +562,7 @@ public abstract class Hooks {
 	}
 
 	@Nullable
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	static Function<Publisher, Publisher> createOrUpdateOpHook(Collection<Function<? super Publisher<Object>, ? extends Publisher<Object>>> hooks) {
 		Function<Publisher, Publisher> composite = null;
 		for (Function<? super Publisher<Object>, ? extends Publisher<Object>> function : hooks) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Hooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -703,6 +703,7 @@ public abstract class Hooks {
 		return addAssemblyInfo(publisher, new AssemblySnapshot(callSite));
 	}
 
+	@SuppressWarnings("unchecked")
 	static <T, P extends Publisher<T>> Publisher<T> addAssemblyInfo(P publisher, AssemblySnapshot stacktrace) {
 		if (publisher instanceof Callable) {
 			if (publisher instanceof Mono) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateIf.java
@@ -203,11 +203,12 @@ final class MonoCacheInvalidateIf<T> extends InternalMonoOperator<T, T> {
 		@SuppressWarnings("rawtypes")
 		private static final CacheMonoSubscriber[] COORDINATOR_INIT = new CacheMonoSubscriber[0];
 
-		@SuppressWarnings("unchecked")
 		CoordinatorSubscriber(MonoCacheInvalidateIf<T> main, Mono<? extends T> source) {
 			this.main = main;
 			this.source = source;
-			this.subscribers = COORDINATOR_INIT;
+			@SuppressWarnings("unchecked")
+			CacheMonoSubscriber<T>[] init = COORDINATOR_INIT;
+			this.subscribers = init;
 		}
 
 		/**
@@ -313,7 +314,6 @@ final class MonoCacheInvalidateIf<T> extends InternalMonoOperator<T, T> {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void onNext(T t) {
 			if (main.state != this || done) {
 				Operators.onNextDropped(t, currentContext());
@@ -323,36 +323,43 @@ final class MonoCacheInvalidateIf<T> extends InternalMonoOperator<T, T> {
 			//note the predicate is not applied upon reception of the value to be cached. only late subscribers will trigger revalidation.
 			State<T> valueState = new ValueState<>(t);
 			if (STATE.compareAndSet(main, this, valueState)) {
-				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
-					inner.complete(t);
+				for (@SuppressWarnings("rawtypes") CacheMonoSubscriber inner :
+						SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					@SuppressWarnings("unchecked")
+					CacheMonoSubscriber<T> _inner = (CacheMonoSubscriber<T>) inner;
+					_inner.complete(t);
 				}
 			}
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void onError(Throwable t) {
 			if (main.state != this || done) {
 				Operators.onErrorDropped(t, currentContext());
 				return;
 			}
 			if (STATE.compareAndSet(main, this, EMPTY_STATE)) {
-				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
-					inner.onError(t);
+				for (@SuppressWarnings("rawtypes") CacheMonoSubscriber inner :
+						SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					@SuppressWarnings("unchecked")
+					CacheMonoSubscriber<T> _inner = (CacheMonoSubscriber<T>) inner;
+					_inner.onError(t);
 				}
 			}
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void onComplete() {
 			if (done) {
 				done = false;
 				return;
 			}
 			if (STATE.compareAndSet(main, this, EMPTY_STATE)) {
-				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
-					inner.onError(new NoSuchElementException("cacheInvalidateWhen expects a value, source completed empty"));
+				for (@SuppressWarnings("rawtypes") CacheMonoSubscriber inner :
+						SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					@SuppressWarnings("unchecked")
+					CacheMonoSubscriber<T> _inner = (CacheMonoSubscriber<T>) inner;
+					_inner.onError(new NoSuchElementException("cacheInvalidateWhen expects a value, source completed empty"));
 				}
 			}
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -162,10 +162,11 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 		@SuppressWarnings("rawtypes")
 		private static final CacheMonoSubscriber[] COORDINATOR_INIT = new CacheMonoSubscriber[0];
 
-		@SuppressWarnings("unchecked")
 		CoordinatorSubscriber(MonoCacheInvalidateWhen<T> main) {
 			this.main = main;
-			this.subscribers = COORDINATOR_INIT;
+			@SuppressWarnings("unchecked")
+			CacheMonoSubscriber<T>[] init = (CacheMonoSubscriber<T>[]) COORDINATOR_INIT;
+			this.subscribers = init;
 		}
 
 		/**
@@ -252,11 +253,13 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 			}
 		}
 
-		@SuppressWarnings("unchecked")
 		boolean cacheLoadFailure(State<T> expected, Throwable failure) {
 			if (STATE.compareAndSet(main, expected, EMPTY_STATE)) {
-				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
-					inner.onError(failure);
+				for (@SuppressWarnings("rawtypes") CacheMonoSubscriber inner :
+						SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					@SuppressWarnings("unchecked")
+					CacheMonoSubscriber<T> _inner = (CacheMonoSubscriber<T>) inner;
+					_inner.onError(failure);
 				}
 				//no need to invalidate, EMPTY_STATE swap above is equivalent for our purpose
 				return true;
@@ -264,7 +267,6 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 			return false;
 		}
 
-		@SuppressWarnings("unchecked")
 		void cacheLoad(T value) {
 			State<T> valueState = new MonoCacheInvalidateIf.ValueState<>(value);
 			if (STATE.compareAndSet(main, this, valueState)) {
@@ -281,8 +283,11 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 					return;
 				}
 
-				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
-					inner.complete(value);
+				for (@SuppressWarnings("rawtypes") CacheMonoSubscriber inner :
+						SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+					@SuppressWarnings("unchecked")
+					CacheMonoSubscriber<T> _inner = (CacheMonoSubscriber<T>) inner;
+					_inner.complete(value);
 				}
 				// even though the trigger can deliver values on different threads,
 				// it's not causing any delivery to downstream, so we don't need to

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCacheInvalidateWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,9 +252,10 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 			}
 		}
 
+		@SuppressWarnings("unchecked")
 		boolean cacheLoadFailure(State<T> expected, Throwable failure) {
 			if (STATE.compareAndSet(main, expected, EMPTY_STATE)) {
-				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
 					inner.onError(failure);
 				}
 				//no need to invalidate, EMPTY_STATE swap above is equivalent for our purpose
@@ -263,6 +264,7 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 			return false;
 		}
 
+		@SuppressWarnings("unchecked")
 		void cacheLoad(T value) {
 			State<T> valueState = new MonoCacheInvalidateIf.ValueState<>(value);
 			if (STATE.compareAndSet(main, this, valueState)) {
@@ -279,7 +281,7 @@ final class MonoCacheInvalidateWhen<T> extends InternalMonoOperator<T, T> {
 					return;
 				}
 
-				for (@SuppressWarnings("unchecked") CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
+				for (CacheMonoSubscriber<T> inner : SUBSCRIBERS.getAndSet(this, COORDINATOR_DONE)) {
 					inner.complete(value);
 				}
 				// even though the trigger can deliver values on different threads,

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoFilterWhen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,9 +82,9 @@ class MonoFilterWhen<T> extends InternalMonoOperator<T, T> {
 		static final AtomicReferenceFieldUpdater<MonoFilterWhenMain, FilterWhenInner> ASYNC_FILTER =
 				AtomicReferenceFieldUpdater.newUpdater(MonoFilterWhenMain.class, FilterWhenInner.class, "asyncFilter");
 
-		@SuppressWarnings({"ConstantConditions", "rawtypes"})
+		@SuppressWarnings({"ConstantConditions", "rawtypes", "unchecked"})
 		static final FilterWhenInner INNER_CANCELLED = new FilterWhenInner(null, false, null);
-		@SuppressWarnings({"ConstantConditions", "rawtypes"})
+		@SuppressWarnings({"ConstantConditions", "rawtypes", "unchecked"})
 		static final FilterWhenInner INNER_TERMINATED = new FilterWhenInner(null, false, null);
 
 		MonoFilterWhenMain(CoreSubscriber<? super T> actual, Function<? super T, ?

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,6 +200,7 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public void cancel() {
 			s.cancel();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoReduce.java
@@ -200,15 +200,15 @@ final class MonoReduce<T> extends MonoFromFluxOperator<T, T>
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void cancel() {
 			s.cancel();
 
 			final T r;
 			synchronized (this) {
 				r = this.aggregate;
-				//noinspection unchecked
-				this.aggregate = (T) CANCELLED;
+				@SuppressWarnings("unchecked")
+				T cancelled = (T) CANCELLED;
+				this.aggregate = cancelled;
 			}
 
 			if (r == null || r == CANCELLED) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,6 +163,7 @@ final class MonoTakeLastOne<T> extends MonoFromFluxOperator<T, T>
 		}
 
 		@Override
+		@SuppressWarnings("unchecked")
 		public void cancel() {
 			s.cancel();
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTakeLastOne.java
@@ -163,15 +163,15 @@ final class MonoTakeLastOne<T> extends MonoFromFluxOperator<T, T>
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public void cancel() {
 			s.cancel();
 
 			final T v;
 			synchronized (this) {
 				v = this.value;
-				//noinspection unchecked
-				this.value = (T) CANCELLED;
+				@SuppressWarnings("unchecked")
+				T cancelled = (T) CANCELLED;
+				this.value = cancelled;
 			}
 
 			if (v != null) {

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoTapRestoringThreadLocals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ final class MonoTapRestoringThreadLocals<T, STATE> extends MonoOperator<T, T> {
 	}
 
 	@Override
+	@SuppressWarnings("try")
 	public void subscribe(CoreSubscriber<? super T> actual) {
 		//if the SignalListener cannot be created, all we can do is error the subscriber.
 		//after it is created, in case doFirst fails we can additionally try to invoke doFinally.

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1033,9 +1033,9 @@ public abstract class Operators {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	static <T> CoreSubscriber<? super T>[] restoreContextOnSubscribers(
 			Publisher<?> publisher, CoreSubscriber<? super T>[] subscribers) {
+		@SuppressWarnings("unchecked")
 		CoreSubscriber<? super T>[] actualSubscribers = new CoreSubscriber[subscribers.length];
 		for (int i = 0; i < subscribers.length; i++) {
 			actualSubscribers[i] = restoreContextOnSubscriber(publisher, subscribers[i]);
@@ -1375,7 +1375,6 @@ public abstract class Operators {
 	 * @param actual the {@link Subscriber} to apply hook on
 	 * @return an eventually transformed {@link Subscriber}
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T> CoreSubscriber<? super T> toCoreSubscriber(Subscriber<? super T> actual) {
 
 		Objects.requireNonNull(actual, "actual");
@@ -1404,7 +1403,6 @@ public abstract class Operators {
 	 * @param actual the {@link Subscriber} to adapt
 	 * @return a potentially adapted {@link reactor.core.Fuseable.ConditionalSubscriber}
 	 */
-	@SuppressWarnings("unchecked")
 	public static <T> Fuseable.ConditionalSubscriber<? super  T> toConditionalSubscriber(CoreSubscriber<? super T> actual) {
 		Objects.requireNonNull(actual, "actual");
 
@@ -2745,10 +2743,11 @@ public abstract class Operators {
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public Publisher<O> apply(Publisher<I> publisher) {
 			if (filter != null && !filter.test(publisher)) {
-				return (Publisher<O>)publisher;
+				@SuppressWarnings("unchecked")
+				Publisher<O> _publisher = (Publisher<O>) publisher;
+				return _publisher;
 			}
 
 			if (publisher instanceof Fuseable) {

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1033,6 +1033,7 @@ public abstract class Operators {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	static <T> CoreSubscriber<? super T>[] restoreContextOnSubscribers(
 			Publisher<?> publisher, CoreSubscriber<? super T>[] subscribers) {
 		CoreSubscriber<? super T>[] actualSubscribers = new CoreSubscriber[subscribers.length];

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyBestEffort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,10 +32,14 @@ import reactor.util.context.Context;
 /**
  * @author Simon Baslé
  */
+@SuppressWarnings("deprecation")
 final class SinkManyBestEffort<T> extends Flux<T>
 		implements InternalManySink<T>, Scannable, DirectInnerContainer<T> {
 
+	@SuppressWarnings("rawtypes")
 	static final DirectInner[] EMPTY      = new DirectInner[0];
+
+	@SuppressWarnings("rawtypes")
 	static final DirectInner[] TERMINATED = new DirectInner[0];
 
 	static final <T> SinkManyBestEffort<T> createBestEffort() {
@@ -299,6 +303,7 @@ final class SinkManyBestEffort<T> extends Flux<T>
 	static class DirectInner<T> extends AtomicBoolean implements InnerProducer<T> {
 
 		final CoreSubscriber<? super T> actual;
+		@SuppressWarnings("deprecation")
 		final DirectInnerContainer<T>   parent;
 
 		volatile     long                                requested;

--- a/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/BoundedElasticScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,6 +194,7 @@ final class BoundedElasticScheduler implements Scheduler,
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void start() {
 		SchedulerState<BoundedServices> a = this.state;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/DelegateServiceScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,7 @@ final class DelegateServiceScheduler implements Scheduler, SchedulerState.Dispos
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void start() {
 		STATE.compareAndSet(this, null,
 				SchedulerState.init(Schedulers.decorateExecutorService(this, original)));

--- a/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ParallelScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,6 +122,7 @@ final class ParallelScheduler implements Scheduler, Supplier<ScheduledExecutorSe
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void start() {
 		SchedulerState<ScheduledExecutorService[]> a = this.state;
 

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -610,14 +610,15 @@ public abstract class Schedulers {
 	 * @param subHook the new {@link BiConsumer} to set as the hook's anonymous part.
 	 * @see #onHandleError(String, BiConsumer)
 	 */
-	@SuppressWarnings("unchecked")
 	public static void onHandleError(BiConsumer<Thread, ? super Throwable> subHook) {
 		Objects.requireNonNull(subHook, "onHandleError");
 		if (LOGGER.isDebugEnabled()) {
 			LOGGER.debug("Hooking onHandleError anonymous part");
 		}
 		synchronized (LOGGER) {
-			onHandleErrorHooks.put(Schedulers.class.getName() + ".ON_HANDLE_ERROR_ANONYMOUS_PART", (BiConsumer<Thread, Throwable>) subHook);
+			@SuppressWarnings("unchecked")
+			BiConsumer<Thread, Throwable> _subHook = (BiConsumer<Thread, Throwable>) subHook;
+			onHandleErrorHooks.put(Schedulers.class.getName() + ".ON_HANDLE_ERROR_ANONYMOUS_PART", _subHook);
 			onHandleErrorHook = createOrAppendHandleError(onHandleErrorHooks.values());
 		}
 	}
@@ -636,7 +637,6 @@ public abstract class Schedulers {
 	 * @param key the {@link String} key identifying the hook part to set/replace.
 	 * @param subHook the new hook part to set for the given key.
 	 */
-	@SuppressWarnings("unchecked")
 	public static void onHandleError(String key, BiConsumer<Thread, ? super Throwable> subHook) {
 		Objects.requireNonNull(key, "key");
 		Objects.requireNonNull(subHook, "onHandleError");
@@ -644,7 +644,9 @@ public abstract class Schedulers {
 			LOGGER.debug("Hooking onHandleError part with key {}", key);
 		}
 		synchronized (LOGGER) {
-			onHandleErrorHooks.put(key, (BiConsumer<Thread, Throwable>) subHook);
+			@SuppressWarnings("unchecked")
+			BiConsumer<Thread, Throwable> _subHook = (BiConsumer<Thread, Throwable>) subHook;
+			onHandleErrorHooks.put(key, _subHook);
 			onHandleErrorHook = createOrAppendHandleError(onHandleErrorHooks.values());
 		}
 	}

--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -610,6 +610,7 @@ public abstract class Schedulers {
 	 * @param subHook the new {@link BiConsumer} to set as the hook's anonymous part.
 	 * @see #onHandleError(String, BiConsumer)
 	 */
+	@SuppressWarnings("unchecked")
 	public static void onHandleError(BiConsumer<Thread, ? super Throwable> subHook) {
 		Objects.requireNonNull(subHook, "onHandleError");
 		if (LOGGER.isDebugEnabled()) {
@@ -1329,6 +1330,7 @@ public abstract class Schedulers {
 		}
 
 		@Override
+		@SuppressWarnings("deprecation")
 		public void start() {
 			cached.start();
 		}

--- a/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/SingleScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ final class SingleScheduler implements Scheduler, Supplier<ScheduledExecutorServ
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public void start() {
 		//TODO SingleTimedScheduler didn't implement start, check if any particular reason?
 		SchedulerState<ScheduledExecutorService> a = this.state;

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,7 +175,8 @@ public class FluxFilterFuseableTest extends FluxOperatorTest<String, String> {
 				    throw new IllegalStateException("boom");
 			    })
 			    .contextWrite(previous -> {
-				    Consumer previousDiscardHandler = previous.get(Hooks.KEY_ON_DISCARD);
+				    Consumer<Object> previousDiscardHandler =
+						    previous.get(Hooks.KEY_ON_DISCARD);
 
 				    return Operators.enableOnDiscard(previous, (discarded) -> {
 					    previousDiscardHandler.accept(discarded);
@@ -298,7 +299,8 @@ public class FluxFilterFuseableTest extends FluxOperatorTest<String, String> {
 			    })
 			    .filter(i -> true)
 			    .contextWrite(previous -> {
-				    Consumer previousDiscardHandler = previous.get(Hooks.KEY_ON_DISCARD);
+				    Consumer<Object> previousDiscardHandler =
+						    previous.get(Hooks.KEY_ON_DISCARD);
 
 				    return Operators.enableOnDiscard(previous, (discarded) -> {
 					    previousDiscardHandler.accept(discarded);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlattenIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -688,6 +688,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 
 	@ParameterizedTestWithName
 	@MethodSource("reactor.core.publisher.FluxIterableTest#factory")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testFluxIterableEmptyCase(Function<Flux, Flux> fn) {
 		Iterable<String> iterable = mock(Iterable.class);
 		Mockito.when(iterable.spliterator())
@@ -707,6 +708,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 
 	@ParameterizedTestWithName
 	@MethodSource("reactor.core.publisher.FluxIterableTest#factory")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testFluxIterableSyncFusionEmptyCase(Function<Flux, Flux> fn) {
 		Iterable<String> iterable = mock(Iterable.class);
 		Mockito.when(iterable.spliterator())
@@ -725,6 +727,7 @@ public class FluxFlattenIterableTest extends FluxOperatorTest<String, String> {
 
 	@ParameterizedTestWithName
 	@MethodSource("reactor.core.publisher.FluxIterableTest#factory")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testFluxIterableErrorHasNext(Function<Flux, Flux> fn) {
 		Iterable<String> iterable = mock(Iterable.class);
 		Spliterator mock = mock(Spliterator.class);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ public class FluxIterableTest {
 
 	final Iterable<Integer> source = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	static Stream<Function<Flux, Flux>> factory() {
 		return Stream.of(new Function<Flux, Flux>() {
 			@Override
@@ -128,6 +129,7 @@ public class FluxIterableTest {
 
 	@ParameterizedTestWithName
 	@MethodSource("factory")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testFluxIterableEmptyCase(Function<Flux, Flux> fn) {
 		Iterable<String> iterable = mock(Iterable.class);
 		Mockito.when(iterable.spliterator())
@@ -145,6 +147,7 @@ public class FluxIterableTest {
 
 	@ParameterizedTestWithName
 	@MethodSource("factory")
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	public void testFluxIterableErrorHasNext(Function<Flux, Flux> fn) {
 		Iterable<String> iterable = mock(Iterable.class);
 		Spliterator mock = mock(Spliterator.class);

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeOrderedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import reactor.util.function.Tuple2;
 import static org.assertj.core.api.Assertions.*;
 
 @Timeout(5)
+@SuppressWarnings("deprecation")
 class FluxMergeOrderedTest {
 
 	//see https://github.com/reactor/reactor-core/issues/1958

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRetryWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.LongAssert;
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
@@ -53,7 +52,7 @@ import reactor.util.retry.RetrySpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 
 public class FluxRetryWhenTest {
 
@@ -751,15 +750,16 @@ public class FluxRetryWhenTest {
 		            .verify(Duration.ofSeconds(1)); //vts test shouldn't even take that long
 
 		assertThat(elapsedList).hasSize(5);
-		assertThat(elapsedList, LongAssert.class).first()
+
+		assertThat(elapsedList).first(LONG)
 				.isEqualTo(0L);
-		assertThat(elapsedList, LongAssert.class).element(1)
+		assertThat(elapsedList).element(1, LONG)
 				.isCloseTo(100, Percentage.withPercentage(10));
-		assertThat(elapsedList, LongAssert.class).element(2)
+		assertThat(elapsedList).element(2, LONG)
 				.isCloseTo(200, Percentage.withPercentage(10));
-		assertThat(elapsedList, LongAssert.class).element(3)
+		assertThat(elapsedList).element(3, LONG)
 				.isCloseTo(400, Percentage.withPercentage(10));
-		assertThat(elapsedList, LongAssert.class).element(4)
+		assertThat(elapsedList).element(4, LONG)
 				.isCloseTo(800, Percentage.withPercentage(10));
 	}
 
@@ -787,15 +787,15 @@ public class FluxRetryWhenTest {
 		            .verify(Duration.ofSeconds(1)); //vts test shouldn't even take that long
 
 		assertThat(elapsedList).hasSize(5);
-		assertThat(elapsedList, LongAssert.class).first()
+		assertThat(elapsedList).first(LONG)
 				.isEqualTo(0L);
-		assertThat(elapsedList, LongAssert.class).element(1)
+		assertThat(elapsedList).element(1, LONG)
 				.isCloseTo(100, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(2)
+		assertThat(elapsedList).element(2, LONG)
 				.isCloseTo(200, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(3)
+		assertThat(elapsedList).element(3, LONG)
 				.isCloseTo(400, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(4)
+		assertThat(elapsedList).element(4, LONG)
 				.isCloseTo(800, Percentage.withPercentage(50));
 	}
 
@@ -820,15 +820,15 @@ public class FluxRetryWhenTest {
 		            .verify(Duration.ofSeconds(1)); //vts test shouldn't even take that long
 
 		assertThat(elapsedList).hasSize(5);
-		assertThat(elapsedList, LongAssert.class).first()
+		assertThat(elapsedList).first(LONG)
 				.isEqualTo(0L);
-		assertThat(elapsedList, LongAssert.class).element(1)
+		assertThat(elapsedList).element(1, LONG)
 				.isCloseTo(100, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(2)
+		assertThat(elapsedList).element(2, LONG)
 				.isCloseTo(200, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(3)
+		assertThat(elapsedList).element(3, LONG)
 				.isCloseTo(400, Percentage.withPercentage(50));
-		assertThat(elapsedList, LongAssert.class).element(4)
+		assertThat(elapsedList).element(4, LONG)
 				.isCloseTo(800, Percentage.withPercentage(50));
 	}
 
@@ -857,24 +857,19 @@ public class FluxRetryWhenTest {
 		            .verify(Duration.ofSeconds(1)); //vts test shouldn't even take that long
 
 		assertThat(elapsedList).hasSize(5);
-		assertThat(elapsedList, LongAssert.class)
-				.first()
+		assertThat(elapsedList).first(LONG)
 				.isEqualTo(0L);
-		assertThat(elapsedList, LongAssert.class)
-				.element(1)
+		assertThat(elapsedList).element(1, LONG)
 				.isGreaterThanOrEqualTo(100) //min backoff
 				.isCloseTo(100, Percentage.withPercentage(90));
-		assertThat(elapsedList, LongAssert.class)
-				.element(2)
+		assertThat(elapsedList).element(2, LONG)
 				.isCloseTo(200, Percentage.withPercentage(90))
 				.isGreaterThanOrEqualTo(100)
 				.isLessThanOrEqualTo(220);
-		assertThat(elapsedList, LongAssert.class)
-				.element(3)
+		assertThat(elapsedList).element(3, LONG)
 				.isGreaterThanOrEqualTo(100)
 				.isLessThanOrEqualTo(220);
-		assertThat(elapsedList, LongAssert.class)
-				.element(4)
+		assertThat(elapsedList).element(4, LONG)
 				.isGreaterThanOrEqualTo(100)
 				.isLessThanOrEqualTo(220);
 	}
@@ -905,11 +900,9 @@ public class FluxRetryWhenTest {
 			            .verify(Duration.ofSeconds(1)); //vts test shouldn't even take that long
 
 			assertThat(elapsedList).hasSize(2);
-			assertThat(elapsedList, LongAssert.class)
-					.first()
+			assertThat(elapsedList).first(LONG)
 					.isEqualTo(0L);
-			assertThat(elapsedList, LongAssert.class)
-					.element(1)
+			assertThat(elapsedList).element(1, LONG)
 					.isGreaterThanOrEqualTo(100) //min backoff
 					.isCloseTo(100, Percentage.withPercentage(90));
 		}

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoFilterWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -351,7 +351,8 @@ public class MonoFilterWhenTest {
 		MonoFilterWhen.MonoFilterWhenMain<String>
 				main = new MonoFilterWhen.MonoFilterWhenMain<>(
 				actual, s -> Mono.just(false));
-		MonoFilterWhen.FilterWhenInner test = new MonoFilterWhen.FilterWhenInner(main, true, null);
+		MonoFilterWhen.FilterWhenInner<String> test =
+				new MonoFilterWhen.FilterWhenInner<>(main, true, null);
 
 		Subscription innerSubscription = Operators.emptySubscription();
 		test.onSubscribe(innerSubscription);

--- a/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OnDiscardShouldNotLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ public class OnDiscardShouldNotLeakTest {
 
 	private static final int NB_ITERATIONS = 100;
 	// add DiscardScenarios here to test more operators
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	private static final DiscardScenario[] SCENARIOS = new DiscardScenario[] {
 			DiscardScenario.allFluxSourceArray("merge", 4, Flux::merge),
 			DiscardScenario.allFluxSourceArray("when", 4,
@@ -78,7 +79,8 @@ public class OnDiscardShouldNotLeakTest {
 					               .thenReturn(Tracked.RELEASED)),
 			DiscardScenario.allFluxSourceArray("zip", 4,
 					sources -> {
-						Publisher<Tracked>[] sources1 = sources.toArray(new Publisher[0]);
+						Publisher<Tracked>[] sources1 =
+								sources.toArray(new Publisher[0]);
 						return Flux.zip(Tuples::fromArray, sources1)
 						           .doOnNext(l -> {
 							           for (Object o : (Iterable<Object>) l) {

--- a/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/AbstractSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void restartSupport() {
 		boolean supportsRestart = shouldCheckSupportRestart();
 		Scheduler s = scheduler();
@@ -161,6 +162,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void acceptTaskAfterStartStopStart() {
 		Assumptions.assumeThat(shouldCheckSupportRestart()).as("scheduler supports restart").isTrue();
 
@@ -353,6 +355,7 @@ public abstract class AbstractSchedulerTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	void multipleRestarts() {
 		Assumptions.assumeThat(shouldCheckSupportRestart()).as("scheduler supports restart").isTrue();
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/ParallelSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,6 +257,7 @@ public class ParallelSchedulerTest extends AbstractSchedulerTest {
 
 	@ParameterizedTestWithName
 	@ValueSource(booleans = {true, false})
+	@SuppressWarnings("deprecation")
 	void restartSupported(boolean disposeGracefully) {
 		Scheduler s = scheduler();
 		if (disposeGracefully) {

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -748,6 +748,7 @@ public class SchedulersTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testCachedSchedulerDelegates() {
 		Scheduler mock = new Scheduler() {
 			@Override
@@ -1077,6 +1078,7 @@ public class SchedulersTest {
 		restart(Schedulers.newSingle("test"));
 	}
 
+	@SuppressWarnings("deprecation")
 	void restart(Scheduler s){
 		Thread t = Mono.fromCallable(Thread::currentThread)
 		               .subscribeOn(s)
@@ -1095,6 +1097,7 @@ public class SchedulersTest {
 	}
 
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testDefaultMethods(){
 		EmptyScheduler s = new EmptyScheduler();
 

--- a/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SingleSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,6 +264,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTest {
 
 	@ParameterizedTestWithName
 	@ValueSource(booleans = {true, false})
+	@SuppressWarnings("deprecation")
 	void restartSupported(boolean disposeGracefully) {
 		Scheduler s = Schedulers.newSingle("restartSupported");
 		if (disposeGracefully) {

--- a/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withContextPropagation102Test/java/reactor/core/publisher/ContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ import reactor.util.context.ContextView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Simon Baslé
@@ -629,7 +630,8 @@ class ContextPropagationTest {
 		@EnumSource(Cases.class)
 		@ParameterizedTestWithName
 		void properWrappingForFluxTap(Cases characteristics) {
-			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
+			@SuppressWarnings("unchecked")
+			SignalListener<String> originalListener = mock(SignalListener.class);
 			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
 				@Override
 				public Void initializePublisherState(Publisher<? extends String> source) {
@@ -705,7 +707,8 @@ class ContextPropagationTest {
 		@EnumSource(Cases.class)
 		@ParameterizedTestWithName
 		void properWrappingForMonoTap(Cases characteristics) {
-			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
+			@SuppressWarnings("unchecked")
+			SignalListener<String> originalListener = mock(SignalListener.class);
 			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
 				@Override
 				public Void initializePublisherState(Publisher<? extends String> source) {
@@ -782,7 +785,8 @@ class ContextPropagationTest {
 			Context context = Context.of(KEY1, "expected");
 			List<String> list = new ArrayList<>();
 
-			SignalListener<Object> tlReadingListener = Mockito.mock(SignalListener.class, invocation -> {
+			@SuppressWarnings("unchecked")
+			SignalListener<Object> tlReadingListener = mock(SignalListener.class, invocation -> {
 				list.add(invocation.getMethod().getName() + ": " + REF1.get());
 				return null;
 			});
@@ -884,7 +888,8 @@ class ContextPropagationTest {
 			BiConsumer<String, SynchronousSink<String>> decoratedHandler = ContextPropagationSupport.shouldRestoreThreadLocalsInSomeOperators() ?
 					ContextPropagation.contextRestoreForHandle(originalHandler, () -> context) : originalHandler;
 
-			SynchronousSink<String> mockSink = Mockito.mock(SynchronousSink.class);
+			@SuppressWarnings("unchecked")
+			SynchronousSink<String> mockSink = mock(SynchronousSink.class);
 			decoratedHandler.accept("bar", mockSink);
 			Mockito.verify(mockSink, Mockito.times(1)).next(expected);
 		}

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/AutomaticContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2023-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1048,6 +1048,7 @@ public class AutomaticContextPropagationTest {
 					    .switchMap(s -> threadSwitchingFlux()));
 		}
 
+		@SuppressWarnings("deprecation")
 		@Test
 		void fluxSwitchMap() {
 			assertThreadLocalsPresentInFlux(() ->

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,6 +171,7 @@ class ContextPropagationTest {
 
 		@EnumSource(Cases.class)
 		@ParameterizedTestWithName
+		@SuppressWarnings("unchecked")
 		void properWrappingForFluxTap(Cases characteristics) {
 			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
 			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
@@ -247,6 +248,7 @@ class ContextPropagationTest {
 
 		@EnumSource(Cases.class)
 		@ParameterizedTestWithName
+		@SuppressWarnings("unchecked")
 		void properWrappingForMonoTap(Cases characteristics) {
 			SignalListener<String> originalListener = Mockito.mock(SignalListener.class);
 			SignalListenerFactory<String, Void> originalFactory = new SignalListenerFactory<String, Void>() {
@@ -320,6 +322,7 @@ class ContextPropagationTest {
 		}
 
 		@Test
+		@SuppressWarnings("unchecked")
 		void threadLocalRestoredInSignalListener() throws InterruptedException {
 			REF1.set(null);
 			Context context = Context.of(KEY1, "expected");
@@ -418,6 +421,7 @@ class ContextPropagationTest {
 		}
 
 		@Test
+		@SuppressWarnings("unchecked")
 		void classContextRestoreHandleConsumerRestoresThreadLocal() {
 			BiConsumer<String, SynchronousSink<String>> originalHandler = (v, sink) -> {
 				if (v.equals("bar")) {

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationWithScopesTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/ContextPropagationWithScopesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ class ContextPropagationWithScopesTest {
 	}
 
 	@Test
+	@SuppressWarnings("try")
 	void emptyContextWorksInMono() {
 		ScopedValue scopedValue = ScopedValue.create("hello");
 		try (Scope scope = Scope.open(scopedValue)) {
@@ -105,6 +106,7 @@ class ContextPropagationWithScopesTest {
 	}
 
 	@Test
+	@SuppressWarnings("try")
 	void subscribeMonoElsewhere() {
 		AtomicReference<ScopedValue> valueInNewThread = new AtomicReference<>();
 
@@ -130,6 +132,7 @@ class ContextPropagationWithScopesTest {
 	}
 
 	@Test
+	@SuppressWarnings("try")
 	void subscribeFluxElsewhere() {
 		AtomicReference<ScopedValue> valueInNewThread = new AtomicReference<>();
 
@@ -155,6 +158,7 @@ class ContextPropagationWithScopesTest {
 	}
 
 	@Test
+	@SuppressWarnings("try")
 	void multiLevelScopesWithDifferentValuesAndFlux() {
 		ScopedValue v1 = ScopedValue.create("val1");
 		ScopedValue v2 = ScopedValue.create("val2");
@@ -201,6 +205,7 @@ class ContextPropagationWithScopesTest {
 	}
 
 	@Test
+	@SuppressWarnings("try")
 	void multiLevelScopesWithDifferentValuesAndMono() {
 		ScopedValue v1 = ScopedValue.create("val1");
 		ScopedValue v2 = ScopedValue.create("val2");

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsFuseableTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static reactor.core.publisher.FluxMetrics.*;
 import static reactor.core.publisher.FluxMetrics.TAG_ON_COMPLETE_EMPTY;
 
+@SuppressWarnings("deprecation")
 public class FluxMetricsFuseableTest {
 
 	private MeterRegistry registry;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/FluxMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import static reactor.core.publisher.FluxMetrics.*;
 import static reactor.core.publisher.FluxMetrics.TAG_ON_COMPLETE_EMPTY;
 import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 
+@SuppressWarnings("deprecation")
 public class FluxMetricsTest {
 
 	private MeterRegistry registry;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsFuseableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static reactor.core.publisher.FluxMetrics.*;
 import static reactor.core.publisher.FluxMetrics.TAG_ON_COMPLETE_EMPTY;
 
+@SuppressWarnings("deprecation")
 public class MonoMetricsFuseableTest {
 
 	private MeterRegistry registry;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/publisher/MonoMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static reactor.core.publisher.FluxMetrics.*;
 import static reactor.test.publisher.TestPublisher.Violation.CLEANUP_ON_TERMINATE;
 
+@SuppressWarnings("deprecation")
 public class MonoMetricsTest {
 
 	private MeterRegistry registry;

--- a/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/core/scheduler/SchedulersMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static reactor.core.scheduler.SchedulerMetricDecorator.TAG_SCHEDULER_ID;
 
+@SuppressWarnings("deprecation")
 public class SchedulersMetricsTest {
 
 

--- a/reactor-core/src/withMicrometerTest/java/reactor/util/MetricsTest.java
+++ b/reactor-core/src/withMicrometerTest/java/reactor/util/MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Simon Baslé
  */
+@SuppressWarnings("deprecation")
 public class MetricsTest {
 
 	@Test

--- a/reactor-tools/src/jarFileTest/java/reactor/tools/JarFileShadingTest.java
+++ b/reactor-tools/src/jarFileTest/java/reactor/tools/JarFileShadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2015-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,9 @@ public class JarFileShadingTest extends AbstractJarFileTest {
 			.containsOnly("net");
 	}
 
+	@SuppressWarnings("unchecked")
 	private ListAssert<String> assertThatFileList(Path path) throws IOException {
-		return (ListAssert) assertThat(Files.list(path))
+		return (ListAssert<String>) assertThat(Files.list(path))
 				.extracting(Path::getFileName)
 				.extracting(Path::toString)
 				.extracting(it -> it.endsWith("/") ? it.substring(0, it.length() - 1) : it);


### PR DESCRIPTION
Over the years some warnings have accumulated. This change adds suppression where unchecked casts, raw types, ignored value of try-with-resources, and deprecated usages are necessary.