### PR TITLE
Refactor to ternary operator

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBuffer.java
@@ -69,15 +69,9 @@ final class FluxBuffer<T, C extends Collection<? super T>> extends InternalFluxO
 
 	@Override
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super C> actual) {
-		if (size == skip) {
-			return new BufferExactSubscriber<>(actual, size, bufferSupplier);
-		}
-		else if (skip > size) {
-			return new BufferSkipSubscriber<>(actual, size, skip, bufferSupplier);
-		}
-		else {
-			return new BufferOverlappingSubscriber<>(actual, size, skip, bufferSupplier);
-		}
+		return (size == skip) ? new BufferExactSubscriber<>(actual, size, bufferSupplier) :
+				(skip > size) ? new BufferSkipSubscriber<>(actual, size, skip, bufferSupplier) :
+						new BufferOverlappingSubscriber<>(actual, size, skip, bufferSupplier);
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3132,10 +3132,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a filtered {@link Mono}
 	 */
 	public final Mono<T> filter(final Predicate<? super T> tester) {
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoFilterFuseable<>(this, tester));
-		}
-		return onAssembly(new MonoFilter<>(this, tester));
+    return onAssembly(this instanceof Fuseable
+        ? new MonoFilterFuseable<>(this, tester)
+        : new MonoFilter<>(this, tester));
 	}
 
 	/**
@@ -3291,10 +3290,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a transformed {@link Mono}
 	 */
 	public final <R> Mono<R> handle(BiConsumer<? super T, SynchronousSink<R>> handler) {
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoHandleFuseable<>(this, handler));
-		}
-		return onAssembly(new MonoHandle<>(this, handler));
+		return (this instanceof Fuseable)
+				? onAssembly(new MonoHandleFuseable<>(this, handler))
+				: onAssembly(new MonoHandle<>(this, handler));
 	}
 
 	/**
@@ -3418,10 +3416,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		SignalLogger<T> log = new SignalLogger<>(this, category, level,
 				showOperatorLine, options);
 
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoLogFuseable<>(this, log));
-		}
-		return onAssembly(new MonoLog<>(this, log));
+		return (this instanceof Fuseable)
+				? onAssembly(new MonoLogFuseable<>(this, log))
+				: onAssembly(new MonoLog<>(this, log));
 	}
 
 
@@ -3468,10 +3465,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 				s -> logger,
 				options);
 
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoLogFuseable<>(this, log));
-		}
-		return onAssembly(new MonoLog<>(this, log));
+		return (this instanceof Fuseable)
+				? onAssembly(new MonoLogFuseable<>(this, log))
+				: onAssembly(new MonoLog<>(this, log));
 	}
 
 	/**
@@ -3486,10 +3482,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @return a new {@link Mono}
 	 */
 	public final <R> Mono<R> map(Function<? super T, ? extends R> mapper) {
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoMapFuseable<>(this, mapper));
-		}
-		return onAssembly(new MonoMap<>(this, mapper));
+		return (this instanceof Fuseable)
+				? onAssembly(new MonoMapFuseable<>(this, mapper))
+				: onAssembly(new MonoMap<>(this, mapper));
 	}
 
 	/**
@@ -3574,11 +3569,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 		if (!Metrics.isInstrumentationAvailable()) {
 			return this;
 		}
-
-		if (this instanceof Fuseable) {
-			return onAssembly(new MonoMetricsFuseable<>(this));
-		}
-		return onAssembly(new MonoMetrics<>(this));
+		
+		return (this instanceof Fuseable)
+				? onAssembly(new MonoMetricsFuseable<>(this))
+				: onAssembly(new MonoMetrics<>(this));
 	}
 
 	/**


### PR DESCRIPTION
### Refactor: use ternary operators for conciseness

This PR refactors a few conditional return statements to use ternary operators in order to improve readability and conciseness.

### Changes:
- Replaced simple `if-else` statements in methods like `Mono#flux()`, `Mono#filter()` with equivalent ternary expressions.
- Ensured that the logic remains unchanged and safe (e.g., `instanceof` checks and casting).

### Rationale:
- Improves brevity and readability where the condition and branches are simple.
- Helps align the style with similar concise expressions already present in the codebase.

Let me know if there's any concern about the use of ternary in these contexts.