### PR TITLE
Fix: Flux.zip does not emit errors from concurrent sources

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxZip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -780,6 +780,12 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 
 		void error(Throwable e, int index) {
 			if (Exceptions.addThrowable(ERROR, this, e)) {
+				// Mark the inner subscriber as 'done' only AFTER this coordinator has
+				// successfully registered the error above.
+				// This specific ordering guarantees that a concurrent drain loop cannot see
+				// `done == true` on the inner subscriber without the coordinator's `error`
+				// field also being visible.
+				subscribers[index].done = true;
 				drain(null, null);
 			}
 			else {
@@ -862,15 +868,31 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 						return;
 					}
 
+					// This block is the central point for terminating the operator.
+					// It is checked at the start of every work cycle inside the drain loop.
+					// We also enter this block on the loop AFTER a terminal condition has been
+					// atomically registered deeper inside the drain logic.
 					if (error != null) {
-						cancelAll();
-						discardAll(missed);
+						if (error == Exceptions.TERMINATED) {
+							// The onComplete() path is specifically triggered when a previous pass through
+							// the drain loop detected that a source had finished cleanly (d && sourceEmpty)
+							// and successfully won a potential race condition to set the `error` field to the TERMINATED
+							// sentinel. The recursive `drain()` call made at that time ensures we re-enter
+							// this loop, hit this check, and can now safely terminate.
+							cancelAll();
+							discardAll(missed);
+							a.onComplete();
+							return;
+						}
+						else {
+							cancelAll();
+							discardAll(missed);
 
-						Throwable ex = Exceptions.terminate(ERROR, this);
+							Throwable ex = Exceptions.terminate(ERROR, this);
 
-						a.onError(ex);
-
-						return;
+							a.onError(ex);
+							return;
+						}
 					}
 
 					boolean empty = false;
@@ -886,11 +908,26 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 
 								boolean sourceEmpty = v == null;
 								if (d && sourceEmpty) {
-									cancelAll();
-									discardAll(missed);
+									// Attempt to claim the error state. In a concurrent scenario,
+									// an onError() from one source could be racing with this onComplete path
+									// from another. `compareAndSet` ensures that only the first signal
+									// to arrive can set the error state using a sentinel value.
+									if (ERROR.compareAndSet(this, null, Exceptions.TERMINATED)) {
+										// If case of a race condition, we have just created a new unit of work: the
+										// drain loop must now see the TERMINATED state and send onComplete().
+										// We call drain() here to safely increment the WIP, which
+										// guarantees the main drain loop will run at least one more time
+										// instead of exiting prematurely.
+										drain(null, null);
+									}
 
-									a.onComplete();
-									return;
+									// We signal to the rest of the drain loop that we cannot produce a
+									// zipped value in this iteration. If we didn't, an early 'break' could leave
+									// the `values` array partially filled, causing an NPE when the zipper
+									// function is called.
+									empty = true;
+
+									break;
 								}
 								if (!sourceEmpty) {
 									values[j] = v;
@@ -955,14 +992,21 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 					}
 
 					if (error != null) {
-						cancelAll();
-						discardAll(missed);
+						if (error == Exceptions.TERMINATED) {
+							cancelAll();
+							discardAll(missed);
+							a.onComplete();
+							return;
+						}
+						else {
+							cancelAll();
+							discardAll(missed);
 
-						Throwable ex = Exceptions.terminate(ERROR, this);
+							Throwable ex = Exceptions.terminate(ERROR, this);
 
-						a.onError(ex);
-
-						return;
+							a.onError(ex);
+							return;
+						}
 					}
 
 					for (int j = 0; j < n; j++) {
@@ -975,11 +1019,11 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 
 								boolean empty = v == null;
 								if (d && empty) {
-									cancelAll();
-									discardAll(missed);
+									if (ERROR.compareAndSet(this, null, Exceptions.TERMINATED)) {
+										drain(null, null);
+									}
 
-									a.onComplete();
-									return;
+									break;
 								}
 								if (!empty) {
 									values[j] = v;
@@ -1134,7 +1178,6 @@ final class FluxZip<T, R> extends Flux<R> implements SourceProducer<R> {
 				Operators.onErrorDropped(t, currentContext());
 				return;
 			}
-			done = true;
 			parent.error(t, index);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/reactor/reactor-core/issues/3917

A race condition existed where a concurrent `onComplete` signal from one source and an `onError` signal from another could result in the `onError` signal being dropped.

Solution:
1. Synchronized Inner Subscriber State: The `ZipCoordinator.error()` method now takes full ownership of the termination sequence. It guarantees that the central error field is set before the inner subscriber's done flag is marked. This closes a timing window where the drain loop could previously see a done subscriber and mistakenly assume a completion.

2. Atomic Terminal State Tie-Breaker: Enhanced the `drain()` loop logic to use `Exceptions.TERMINATED` as an atomic sentinel value. This acts as a definitive tie-breaker for racing terminal signals. We ensure that only the first signal (either an error or a completion) can claim the terminal state, with any subsequent signals being correctly handled or dropped.