### PR TITLE
Revert "Update the support section"

### DIFF
--- a/docs/modules/ROOT/pages/gettingStarted.adoc
+++ b/docs/modules/ROOT/pages/gettingStarted.adoc
@@ -238,4 +238,6 @@ repositories {
 [[support]]
 == Support and policies
 
-Support information can be found on the https://projectreactor.io/support[Reactor Support] page.
+The entries below are mirroring https://github.com/reactor/.github/blob/main/SUPPORT.adoc
+
+include::partial$SUPPORT.adoc[leveloffset=2]


### PR DESCRIPTION
Reverts reactor/reactor-core#4050

The previous change removed more sections than anticipated.  Reverting this change as the support link is included in the SUPPORT.adoc that is in the include statement