### PR TITLE
Fix: Sinks queue is not cleared on immediate cancellation

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyStressTest.java
+++ b/reactor-core/src/jcstress/java/reactor/core/publisher/SinkManyStressTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import java.util.Queue;
+
+public class SinkManyStressTest {
+
+    @JCStressTest
+    @Outcome(id = {"0"}, expect = Expect.ACCEPTABLE, desc = "Queue was correctly cleared.")
+    @Outcome(id = {"1"}, expect = Expect.FORBIDDEN, desc = "Item was leaked into the queue.")
+    @State
+    public static class SinkManyTakeZeroTest {
+        final SinkManyEmitterProcessor<Object> sink = new SinkManyEmitterProcessor<>(true, 16);
+
+        @Actor
+        public void takeZero() {
+            sink.asFlux().take(0).blockLast();
+        }
+
+        @Actor
+        public void emit() {
+            sink.tryEmitNext("Test emit");
+        }
+
+        @Arbiter
+        public void arbiter(I_Result result) {
+            Queue<?> q = sink.queue;
+            result.r1 = q == null ? 0 : q.size();
+        }
+
+    }
+}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxLimitRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ final class FluxLimitRequest<T> extends InternalFluxOperator<T, T> {
 	@Nullable
 	public CoreSubscriber<? super T> subscribeOrReturn(CoreSubscriber<? super T> actual) {
 		if (this.cap == 0) {
+			if (super.source instanceof SourceProducer) {
+				((SourceProducer<?>) super.source).terminateAndCleanup();
+			}
 			Operators.complete(actual);
 			return null;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/SourceProducer.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SourceProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,5 +46,29 @@ interface SourceProducer<O> extends Scannable, Publisher<O> {
 	@Override
 	default String stepName() {
 		return "source(" + getClass().getSimpleName() + ")";
+	}
+
+	/**
+	 * An internal hook for operators to instruct this {@link SourceProducer} to terminate
+	 * and clean up its resources, bypassing the standard subscription-cancellation path.
+	 * <p>
+	 * This method is necessary for specific scenarios where a downstream consumer
+	 * terminates prematurely *without* propagating a standard
+	 * {@link org.reactivestreams.Subscription#cancel() cancel} signal upstream. The primary
+	 * use case is for operators that short-circuit the stream, such as {@code take(0)}.
+	 * <p>
+	 * Without this direct termination signal, a hot source with a buffer (like a
+	 * {@code Sinks.many().unicast().onBackpressureBuffer(queue)}) could be orphaned, leading to its buffered
+	 * elements never being released and causing a memory leak.
+	 * <p>
+	 * This is not intended for public use and should only be called by Reactor framework
+	 * operators. The default implementation is a no-op, allowing sources to opt in to this
+	 * behavior only if they manage resources that require explicit cleanup in such scenarios.
+	 *
+	 * @see reactor.core.publisher.Flux#take(long)
+	 * @see SinkManyUnicast
+	 */
+	default void terminateAndCleanup() {
+		// Default implementation does nothing.
 	}
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -921,5 +921,15 @@ class SinkManyEmitterProcessorTest {
 		            .expectNext(1)
 		            .expectTimeout(Duration.ofSeconds(1))
 		            .verify();
+	}
+
+	@Test
+	void shouldClearQueueOnImmediateCancellation() {
+		SinkManyEmitterProcessor<Integer> processor = new SinkManyEmitterProcessor<>(true, 1);
+		processor.tryEmitNext(1);
+		assertThat(processor.queue.size()).isEqualTo(1);
+
+		processor.asFlux().take(0).blockLast();
+		assertThat(processor.queue.size()).isEqualTo(0);
 	}
 }


### PR DESCRIPTION
Resolves #3359 

This PR resolves an issue where elements buffered in a `Sinks.many().unicast().onBackpressureBuffer()` or `Sinks.many().multicast().onBackpressureBuffer()` sink were not discarded if the downstream consumer cancelled immediately, most notably through operators like `.take(0)`.

**Root cause:**
The `.take(0)` operator creates a `FluxLimitRequest` instance, which is an `OptimizableOperator`.

During the subscription phase, the `subscribeOrReturn` is getting called on this operator before propagating the subscription to the upstream source (SinkManyUnicast).

Because the take limit is 0, `FluxLimitRequest` immediately completes the downstream subscriber and returns null. This null return signals that the subscription chain should be terminated.

As a result, `subscribe()` is never called on the SinkManyUnicast. The sink is left unaware that a consumer ever attempted to connect and its cancellation and cleanup logic, which would clear the buffer, is never triggered.

**Solution:**
The affected Sinks implement the `SourceProducer` interface and override a method that provides an opt-in side-channel for operators to signal a source to release its resources, bypassing the standard subscription path.