### PR TITLE
Adjust reactor.util.Logger vararg nullability

### DIFF
--- a/reactor-core/src/jcstress/java/reactor/core/util/FastLogger.java
+++ b/reactor-core/src/jcstress/java/reactor/core/util/FastLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2022-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
 import reactor.util.Logger;
 
 /**
@@ -86,7 +87,7 @@ public class FastLogger implements Logger {
 	}
 
 	@Override
-	public void trace(String format, Object... arguments) {
+	public void trace(String format, @Nullable Object @Nullable... arguments) {
 		trace(String.format(format, arguments));
 	}
 
@@ -106,7 +107,7 @@ public class FastLogger implements Logger {
 	}
 
 	@Override
-	public void debug(String format, Object... arguments) {
+	public void debug(String format, @Nullable Object @Nullable... arguments) {
 
 	}
 
@@ -126,7 +127,7 @@ public class FastLogger implements Logger {
 	}
 
 	@Override
-	public void info(String format, Object... arguments) {
+	public void info(String format, @Nullable Object @Nullable... arguments) {
 
 	}
 
@@ -146,7 +147,7 @@ public class FastLogger implements Logger {
 	}
 
 	@Override
-	public void warn(String format, Object... arguments) {
+	public void warn(String format, @Nullable Object @Nullable... arguments) {
 
 	}
 
@@ -166,7 +167,7 @@ public class FastLogger implements Logger {
 	}
 
 	@Override
-	public void error(String format, Object... arguments) {
+	public void error(String format, @Nullable Object @Nullable... arguments) {
 
 	}
 

--- a/reactor-core/src/main/java/reactor/util/Logger.java
+++ b/reactor-core/src/main/java/reactor/util/Logger.java
@@ -75,7 +75,7 @@ public interface Logger {
 	 * @param format    the format string
 	 * @param arguments a list of 3 or more arguments
 	 */
-	void trace(String format, @Nullable Object... arguments);
+	void trace(String format, @Nullable Object @Nullable... arguments);
 
 	/**
 	 * Log an exception (throwable) at the TRACE level with an
@@ -113,7 +113,7 @@ public interface Logger {
 	 * @param format    the format string
 	 * @param arguments a list of 3 or more arguments
 	 */
-	void debug(String format, Object... arguments);
+	void debug(String format, @Nullable Object @Nullable... arguments);
 
 	/**
 	 * Log an exception (throwable) at the DEBUG level with an
@@ -151,7 +151,7 @@ public interface Logger {
 	 * @param format    the format string
 	 * @param arguments a list of 3 or more arguments
 	 */
-	void info(String format, Object... arguments);
+	void info(String format, @Nullable Object @Nullable... arguments);
 
 	/**
 	 * Log an exception (throwable) at the INFO level with an
@@ -233,7 +233,7 @@ public interface Logger {
 	 * @param format    the format string
 	 * @param arguments a list of 3 or more arguments
 	 */
-	void warn(String format, Object... arguments);
+	void warn(String format, @Nullable Object @Nullable... arguments);
 
 	/**
 	 * Log an exception (throwable) at the WARN level with an
@@ -315,7 +315,7 @@ public interface Logger {
 	 * @param format    the format string
 	 * @param arguments a list of 3 or more arguments
 	 */
-	void error(String format, Object... arguments);
+	void error(String format, @Nullable Object @Nullable... arguments);
 
 	/**
 	 * Log an exception (throwable) at the ERROR level with an

--- a/reactor-core/src/main/java/reactor/util/Loggers.java
+++ b/reactor-core/src/main/java/reactor/util/Loggers.java
@@ -235,7 +235,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void trace(String format, Object... arguments) {
+		public void trace(String format, @Nullable Object @Nullable... arguments) {
 			logger.trace(format, arguments);
 		}
 
@@ -255,7 +255,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void debug(String format, Object... arguments) {
+		public void debug(String format, @Nullable Object @Nullable... arguments) {
 			logger.debug(format, arguments);
 		}
 
@@ -275,7 +275,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void info(String format, Object... arguments) {
+		public void info(String format, @Nullable Object @Nullable... arguments) {
 			logger.info(format, arguments);
 		}
 
@@ -295,7 +295,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void warn(String format, Object... arguments) {
+		public void warn(String format, @Nullable Object @Nullable... arguments) {
 			logger.warn(format, arguments);
 		}
 
@@ -315,7 +315,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void error(String format, Object... arguments) {
+		public void error(String format, @Nullable Object @Nullable... arguments) {
 			logger.error(format, arguments);
 		}
 
@@ -352,7 +352,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void trace(String format, Object... arguments) {
+		public void trace(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(Level.FINEST, format, arguments);
 		}
 
@@ -372,7 +372,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void debug(String format, Object... arguments) {
+		public void debug(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(Level.FINE, format, arguments);
 		}
 
@@ -392,7 +392,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void info(String format, Object... arguments) {
+		public void info(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(Level.INFO, format, arguments);
 		}
 
@@ -412,7 +412,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void warn(String format, Object... arguments) {
+		public void warn(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(Level.WARNING, format, arguments);
 		}
 
@@ -432,7 +432,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void error(String format, Object... arguments) {
+		public void error(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(Level.SEVERE, format, arguments);
 		}
 
@@ -441,11 +441,13 @@ public abstract class Loggers {
 			logger.log(Level.SEVERE, msg, t);
 		}
 
-		private @Nullable String format(@Nullable String from, Object @Nullable[] arguments) {
+		private @Nullable String format(@Nullable String from,
+				@Nullable Object @Nullable [] arguments) {
 			return format(from, arguments, false);
 		}
 
-		private @Nullable String format(@Nullable String from, Object @Nullable[] arguments, boolean skipLast) {
+		private @Nullable String format(@Nullable String from,
+				@Nullable Object @Nullable [] arguments, boolean skipLast) {
 			if (from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
@@ -455,7 +457,8 @@ public abstract class Loggers {
 					}
 
 					for (int index = 0; index < lastIndex; ++index) {
-						computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(arguments[index])));
+						computed = computed.replaceFirst("\\{\\}",
+								Matcher.quoteReplacement(String.valueOf(arguments[index])));
 					}
 				}
 				return computed;
@@ -463,7 +466,8 @@ public abstract class Loggers {
 			return null;
 		}
 
-		private void logWithPotentialThrowable(Level level, String format, Object... arguments) {
+		private void logWithPotentialThrowable(Level level, String format,
+				@Nullable Object @Nullable... arguments) {
 			Throwable t = getPotentialThrowable(arguments);
 			if (t != null) {
 				logger.log(level, format(format, arguments, true), t);
@@ -473,7 +477,7 @@ public abstract class Loggers {
 			logger.log(level, format(format, arguments));
 		}
 
-		private @Nullable Throwable getPotentialThrowable(Object... arguments) {
+		private @Nullable Throwable getPotentialThrowable(@Nullable Object @Nullable... arguments) {
 			if (arguments == null) {
 				return null;
 			}
@@ -524,11 +528,11 @@ public abstract class Loggers {
 			return identifier.name;
 		}
 
-		private @Nullable String format(@Nullable String from, Object @Nullable[] arguments) {
+		private @Nullable String format(@Nullable String from, @Nullable Object @Nullable[] arguments) {
 			return format(from, arguments, false);
 		}
 
-		private @Nullable String format(@Nullable String from, Object @Nullable[] arguments, boolean skipLast) {
+		private @Nullable String format(@Nullable String from, @Nullable Object @Nullable[] arguments, boolean skipLast) {
 			if (from != null) {
 				String computed = from;
 				if (arguments != null && arguments.length != 0) {
@@ -546,7 +550,7 @@ public abstract class Loggers {
 			return null;
 		}
 
-		private synchronized void logWithPotentialThrowable(PrintStream logger, String level, String format, Object... arguments) {
+		private synchronized void logWithPotentialThrowable(PrintStream logger, String level, String format, @Nullable Object @Nullable... arguments) {
 			Throwable t = getPotentialThrowable(arguments);
 			if (t != null) {
 				logger.format(
@@ -567,7 +571,7 @@ public abstract class Loggers {
 			);
 		}
 
-		private static @Nullable Throwable getPotentialThrowable(Object... arguments) {
+		private static @Nullable Throwable getPotentialThrowable(@Nullable Object @Nullable... arguments) {
 			if (arguments == null) {
 				return null;
 			}
@@ -594,7 +598,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void trace(String format, Object... arguments) {
+		public void trace(String format, @Nullable Object @Nullable... arguments) {
 			if (!identifier.verbose) {
 				return;
 			}
@@ -624,7 +628,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void debug(String format, Object... arguments) {
+		public void debug(String format, @Nullable Object @Nullable... arguments) {
 			if (!identifier.verbose) {
 				return;
 			}
@@ -651,7 +655,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void info(String format, Object... arguments) {
+		public void info(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(this.log, " INFO", format, arguments);
 		}
 
@@ -672,7 +676,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void warn(String format, Object... arguments) {
+		public void warn(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(this.err, " WARN", format, arguments);
 		}
 
@@ -693,7 +697,7 @@ public abstract class Loggers {
 		}
 
 		@Override
-		public void error(String format, Object... arguments) {
+		public void error(String format, @Nullable Object @Nullable... arguments) {
 			logWithPotentialThrowable(this.err, "ERROR", format, arguments);
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SignalLoggerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.logging.Level;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.reactivestreams.Subscription;
@@ -42,8 +43,8 @@ public class SignalLoggerTests {
 	public void safeLogsWhenLoggerThrows() {
 		TestLogger logger = new TestLogger() {
 			@Override
-			public synchronized void info(String format, Object... arguments) {
-				if (arguments[0] instanceof SignalType && arguments[1] instanceof Integer) {
+			public synchronized void info(String format, @Nullable Object @Nullable... arguments) {
+				if (arguments != null && arguments[0] instanceof SignalType && arguments[1] instanceof Integer) {
 					throw new UnsupportedOperationException("boom on integer");
 				}
 				super.info(format, arguments);
@@ -406,7 +407,10 @@ public class SignalLoggerTests {
 			return str.toString();
 		}
 
-		private Object[] wrapArguments(Object... arguments) {
+		private Object[] wrapArguments(@Nullable Object @Nullable... arguments) {
+			if (arguments == null) {
+				return null;
+			}
 			Object[] args = new Object[arguments.length];
 			for (int i = 0; i < arguments.length; i++) {
 				args[i] = collectionAsString(arguments[i]);
@@ -430,7 +434,7 @@ public class SignalLoggerTests {
 		}
 
 		@Override
-		public void trace(String format, Object... arguments) {
+		public void trace(String format, @Nullable Object @Nullable... arguments) {
 			delegate.trace(format, wrapArguments(arguments));
 		}
 
@@ -450,7 +454,7 @@ public class SignalLoggerTests {
 		}
 
 		@Override
-		public void debug(String format, Object... arguments) {
+		public void debug(String format, @Nullable Object @Nullable... arguments) {
 			delegate.debug(format, wrapArguments(arguments));
 		}
 
@@ -470,7 +474,7 @@ public class SignalLoggerTests {
 		}
 
 		@Override
-		public void info(String format, Object... arguments) {
+		public void info(String format, @Nullable Object @Nullable... arguments) {
 			delegate.info(format, wrapArguments(arguments));
 		}
 
@@ -490,7 +494,7 @@ public class SignalLoggerTests {
 		}
 
 		@Override
-		public void warn(String format, Object... arguments) {
+		public void warn(String format, @Nullable Object @Nullable... arguments) {
 			delegate.warn(format, wrapArguments(arguments));
 		}
 
@@ -510,7 +514,7 @@ public class SignalLoggerTests {
 		}
 
 		@Override
-		public void error(String format, Object... arguments) {
+		public void error(String format, @Nullable Object @Nullable... arguments) {
 			delegate.error(format, wrapArguments(arguments));
 		}
 

--- a/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
+++ b/reactor-test/src/main/java/reactor/test/util/LoggerUtils.java
@@ -210,7 +210,7 @@ public final class LoggerUtils {
 		}
 
 		@Override
-		public void trace(String format, Object... arguments) {
+		public void trace(String format, @Nullable Object @Nullable... arguments) {
 			Logger logger = parent.getCapturingLogger();
 			if (logger != null) {
 				logger.trace(format, arguments);
@@ -249,7 +249,7 @@ public final class LoggerUtils {
 		}
 
 		@Override
-		public void debug(String format, Object... arguments) {
+		public void debug(String format, @Nullable Object @Nullable... arguments) {
 			Logger logger = parent.getCapturingLogger();
 			if (logger != null) {
 				logger.debug(format, arguments);
@@ -288,7 +288,7 @@ public final class LoggerUtils {
 		}
 
 		@Override
-		public void info(String format, Object... arguments) {
+		public void info(String format, @Nullable Object @Nullable... arguments) {
 			Logger logger = parent.getCapturingLogger();
 			if (logger != null) {
 				logger.info(format, arguments);
@@ -327,7 +327,7 @@ public final class LoggerUtils {
 		}
 
 		@Override
-		public void warn(String format, Object... arguments) {
+		public void warn(String format, @Nullable Object @Nullable... arguments) {
 			Logger logger = parent.getCapturingLogger();
 			if (logger != null) {
 				logger.warn(format, arguments);
@@ -366,7 +366,7 @@ public final class LoggerUtils {
 		}
 
 		@Override
-		public void error(String format, Object... arguments) {
+		public void error(String format, @Nullable Object @Nullable... arguments) {
 			Logger logger = parent.getCapturingLogger();
 			if (logger != null) {
 				logger.error(format, arguments);

--- a/reactor-test/src/main/java/reactor/test/util/TestLogger.java
+++ b/reactor-test/src/main/java/reactor/test/util/TestLogger.java
@@ -72,12 +72,12 @@ public class TestLogger implements Logger {
 		this.logContent.reset();
 	}
 
-	private @Nullable String format(@Nullable String from, @Nullable Object... arguments) {
+	private @Nullable String format(@Nullable String from, @Nullable Object @Nullable... arguments) {
 		if(from != null) {
 			String computed = from;
 			if (arguments != null && arguments.length != 0) {
 				for (Object argument : arguments) {
-					computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(argument.toString()));
+					computed = computed.replaceFirst("\\{\\}", Matcher.quoteReplacement(String.valueOf(argument)));
 				}
 			}
 			return computed;
@@ -96,7 +96,7 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
-	public synchronized void trace(String format, Object... arguments) {
+	public synchronized void trace(String format, @Nullable Object @Nullable... arguments) {
 		this.log.format(logContent("TRACE", format(format, arguments)));
 	}
 	@Override
@@ -116,7 +116,7 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
-	public synchronized void debug(String format, Object... arguments) {
+	public synchronized void debug(String format, @Nullable Object @Nullable... arguments) {
 		this.log.format(logContent("DEBUG", format(format, arguments)));
 	}
 
@@ -137,7 +137,7 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
-	public synchronized void info(String format, Object... arguments) {
+	public synchronized void info(String format, @Nullable Object @Nullable... arguments) {
 		this.log.format(logContent(" INFO", format(format, arguments)));
 	}
 
@@ -158,7 +158,7 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
-	public synchronized void warn(String format, Object... arguments) {
+	public synchronized void warn(String format, @Nullable Object @Nullable... arguments) {
 		this.err.format(logContent(" WARN", format(format, arguments)));
 	}
 
@@ -179,7 +179,7 @@ public class TestLogger implements Logger {
 	}
 
 	@Override
-	public synchronized void error(String format, Object... arguments) {
+	public synchronized void error(String format, @Nullable Object @Nullable... arguments) {
 		this.err.format(logContent("ERROR", format(format, arguments)));
 	}
 

--- a/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
+++ b/reactor-test/src/test/java/reactor/test/util/TestLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2021-2025 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,5 +178,80 @@ class TestLoggerTest {
 				"[ERROR] msg2",
 				"[ERROR] msg - reactor.core.Exceptions$StaticThrowable: Operator has been terminated",
 				"reactor.core.Exceptions$StaticThrowable: Operator has been terminated");
+	}
+
+	@Test
+	void traceLogsNullArgument() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.trace("msg {}", (Object) null);
+		testLogger.trace("msg {} {}", 1, null);
+		testLogger.trace("msg {} {} {}", 1, null, 3);
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+		assertThat(testLogger.getOutContent().split(System.lineSeparator()))
+				.as("out")
+				.containsExactly(
+						"[TRACE] msg null",
+						"[TRACE] msg 1 null",
+						"[TRACE] msg 1 null 3");
+	}
+
+	@Test
+	void debugLogsNullArgument() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.debug("msg {}", (Object) null);
+		testLogger.debug("msg {} {}", 1, null);
+		testLogger.debug("msg {} {} {}", 1, null, 3);
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+		assertThat(testLogger.getOutContent().split(System.lineSeparator()))
+				.as("out")
+				.containsExactly(
+						"[DEBUG] msg null",
+						"[DEBUG] msg 1 null",
+						"[DEBUG] msg 1 null 3");
+	}
+
+	@Test
+	void infoLogsNullArgument() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.info("msg {}", (Object) null);
+		testLogger.info("msg {} {}", 1, null);
+		testLogger.info("msg {} {} {}", 1, null, 3);
+		assertThat(testLogger.getErrContent()).as("err").isEmpty();
+		assertThat(testLogger.getOutContent().split(System.lineSeparator()))
+				.as("out")
+				.containsExactly(
+						"[ INFO] msg null",
+						"[ INFO] msg 1 null",
+						"[ INFO] msg 1 null 3");
+	}
+
+	@Test
+	void warnLogsNullArgument() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.warn("msg {}", (Object) null);
+		testLogger.warn("msg {} {}", 1, null);
+		testLogger.warn("msg {} {} {}", 1, null, 3);
+		assertThat(testLogger.getOutContent()).as("out").isEmpty();
+		assertThat(testLogger.getErrContent().split(System.lineSeparator()))
+				.as("err")
+				.containsExactly(
+						"[ WARN] msg null",
+						"[ WARN] msg 1 null",
+						"[ WARN] msg 1 null 3");
+	}
+
+	@Test
+	void errorLogsNullArgument() {
+		TestLogger testLogger = new TestLogger(false);
+		testLogger.error("msg {}", (Object) null);
+		testLogger.error("msg {} {}", 1, null);
+		testLogger.error("msg {} {} {}", 1, null, 3);
+		assertThat(testLogger.getOutContent()).as("out").isEmpty();
+		assertThat(testLogger.getErrContent().split(System.lineSeparator()))
+				.as("err")
+				.containsExactly(
+						"[ERROR] msg null",
+						"[ERROR] msg 1 null",
+						"[ERROR] msg 1 null 3");
 	}
 }


### PR DESCRIPTION
With JSpecify annotations, array and varargs nullability checks are more expressive and provide more out-of-the-box strictness. The reactor.util.Logger interface has relaxed requirements regarding varargs parameters when logging so that is now reflected using the type-use annotations syntax.
Additionally, the TestLogger was adjusted to avoid NPE when null varargs elements are provided.

Resolves #4095 