### PR TITLE
Fix elapsed time computation in OptimisticEmitFailureHandler

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -224,20 +224,22 @@ public final class Sinks {
 	}
 
 	/**
-	 *
 	 * @author Animesh Chaturvedi
 	 */
 	static class OptimisticEmitFailureHandler implements EmitFailureHandler {
 
+        private final long startTime;
 		private final long deadline;
 
 		OptimisticEmitFailureHandler(Duration duration){
-			this.deadline = System.nanoTime() + duration.toNanos();
+            this.startTime = System.nanoTime();
+			this.deadline = duration.toNanos();
 		}
 
 		@Override
 		public boolean onEmitFailure(SignalType signalType, EmitResult emitResult) {
-			return emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED) && (System.nanoTime() < this.deadline);
+			return emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED)
+                    && System.nanoTime() - startTime < deadline;
 		}
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,23 +228,21 @@ public final class Sinks {
 	 */
 	static class OptimisticEmitFailureHandler implements EmitFailureHandler {
 
-        private final long startTime;
 		private final long deadline;
 
 		OptimisticEmitFailureHandler(Duration duration){
-            this.startTime = System.nanoTime();
-			this.deadline = duration.toNanos();
+			this.deadline = System.nanoTime() + duration.toNanos();
 		}
 
 		@Override
 		public boolean onEmitFailure(SignalType signalType, EmitResult emitResult) {
 			return emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED)
-                    && System.nanoTime() - startTime < deadline;
+					&& deadline - System.nanoTime() > 0; // difference is used to tackle a numeric overflow
 		}
 	}
 
 	/**
-	 * A handler supporting the emit API (eg. {@link Many#emitNext(Object, Sinks.EmitFailureHandler)}),
+	 * A handler supporting the emit API (e.g. {@link Many#emitNext(Object, Sinks.EmitFailureHandler)}),
 	 * checking non-successful emission results from underlying {@link Many#tryEmitNext(Object) tryEmit}
 	 * API calls to decide whether or not such calls should be retried.
 	 * Other than instructing to retry, the handlers are allowed to have side effects


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->

This change addresses the elapsed time computation in `OptimisticEmitFailureHandler` due to the possibility of a numerical overflow. The described behavior isn't changed from user's perspective.

Javadoc of System.nanoTime() explicitly mentions how to measure elapsed time.
> To compare elapsed time against a timeout, use
> `if (System.nanoTime() - startTime >= timeoutNanos) ...`
> instead of
> `if (System.nanoTime() >= startTime + timeoutNanos) ...`
> because of the possibility of **numerical overflow**.

<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->
See [System.nanoTime()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/System.html#nanoTime())