### PR TITLE
Adjust Mono methods: fromCallable and fromSupplier nullability

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -515,13 +515,13 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/fromCallable.svg" alt="">
 	 * <p>
-	 * @param supplier {@link Callable} that will produce the value
+	 * @param callable {@link Callable} that will produce the value
 	 * @param <T> type of the expected value
 	 *
 	 * @return A {@link Mono}.
 	 */
-	public static <T> Mono<T> fromCallable(Callable<? extends T> supplier) {
-		return onAssembly(new MonoCallable<>(supplier));
+	public static <T> Mono<T> fromCallable(Callable<? extends @Nullable T> callable) {
+		return onAssembly(new MonoCallable<>(callable));
 	}
 
 	/**
@@ -709,7 +709,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @return A {@link Mono}.
 	 */
-	public static <T> Mono<T> fromSupplier(Supplier<? extends T> supplier) {
+	public static <T> Mono<T> fromSupplier(Supplier<? extends @Nullable T> supplier) {
 		return onAssembly(new MonoSupplier<>(supplier));
 	}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoCallable.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoCallable.java
@@ -37,9 +37,9 @@ import reactor.core.Fuseable;
 final class MonoCallable<T> extends Mono<T>
 		implements Callable<T>, Fuseable, SourceProducer<T> {
 
-	final Callable<? extends T> callable;
+	final Callable<? extends @Nullable T> callable;
 
-	MonoCallable(Callable<? extends T> callable) {
+	MonoCallable(Callable<? extends @Nullable T> callable) {
 		this.callable = Objects.requireNonNull(callable, "callable");
 	}
 
@@ -55,7 +55,7 @@ final class MonoCallable<T> extends Mono<T>
 	}
 
 	@Override
-	public T block(Duration m) {
+	public @Nullable T block(Duration m) {
 		try {
 			return callable.call();
 		}
@@ -65,7 +65,7 @@ final class MonoCallable<T> extends Mono<T>
 	}
 
 	@Override
-	public T call() throws Exception {
+	public @Nullable T call() throws Exception {
 		return callable.call();
 	}
 
@@ -79,7 +79,7 @@ final class MonoCallable<T> extends Mono<T>
 			implements InnerProducer<T>, Fuseable, QueueSubscription<T> {
 
 		final CoreSubscriber<? super T> actual;
-		final Callable<? extends T>     callable;
+		final Callable<? extends @Nullable T> callable;
 
 		boolean done;
 
@@ -91,7 +91,7 @@ final class MonoCallable<T> extends Mono<T>
 
 		volatile boolean cancelled;
 
-		MonoCallableSubscription(CoreSubscriber<? super T> actual, Callable<? extends T> callable) {
+		MonoCallableSubscription(CoreSubscriber<? super T> actual, Callable<? extends @Nullable T> callable) {
 			this.actual = actual;
 			this.callable = callable;
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSupplier.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSupplier.java
@@ -36,10 +36,10 @@ final class MonoSupplier<T>
 extends Mono<T>
 		implements Callable<T>, Fuseable, SourceProducer<T>  {
 
-	final Supplier<? extends T> supplier;
+	final Supplier<? extends @Nullable T> supplier;
 
-	MonoSupplier(Supplier<? extends T> callable) {
-		this.supplier = Objects.requireNonNull(callable, "callable");
+	MonoSupplier(Supplier<? extends @Nullable T> supplier) {
+		this.supplier = Objects.requireNonNull(supplier, "supplier");
 	}
 
 	@Override
@@ -73,7 +73,7 @@ extends Mono<T>
 			implements InnerProducer<T>, Fuseable, QueueSubscription<T> {
 
 		final CoreSubscriber<? super T> actual;
-		final Supplier<? extends T>     supplier;
+		final Supplier<? extends @Nullable T> supplier;
 
 		boolean done;
 
@@ -84,9 +84,10 @@ extends Mono<T>
 
 		volatile boolean cancelled;
 
-		MonoSupplierSubscription(CoreSubscriber<? super T> actual, Supplier<? extends T> callable) {
+		MonoSupplierSubscription(CoreSubscriber<? super T> actual,
+				Supplier<? extends @Nullable T> supplier) {
 			this.actual = actual;
-			this.supplier = callable;
+			this.supplier = supplier;
 		}
 
 		@Override


### PR DESCRIPTION
These methods do handle null properly and the behaviour is well defined in the javadoc.