### PR TITLE
feat: Improved logging performance by replacing regular expression

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SignalLogger.java
@@ -238,11 +238,17 @@ final class SignalLogger<IN> implements SignalPeek<IN> {
 		if (name == null) {
 			name = clazz.getName();
 		}
-		name = name.replaceFirst(clazz.getPackage()
-		                              .getName() + ".", "");
-		asString.append(name);
 
-		return asString.toString();
+        String packageNameWithDot = clazz.getPackage().getName() + '.';
+        int indexOfPackageName = name.indexOf(packageNameWithDot);
+        int indexAfterPackage = indexOfPackageName + packageNameWithDot.length();
+        if (indexOfPackageName != -1 && name.length() > indexAfterPackage) {
+            asString.append(name, indexAfterPackage, name.length());
+        } else {
+            asString.append(name);
+        }
+
+        return asString.toString();
 	}
 
 	@Override


### PR DESCRIPTION
<!-- What changes from the user's perspective? -->
This change improves performance for those using the logging operations of Reactor.

<!-- Next paragraph contains more technical details -->
The old implementation used `String#replaceFirst` as it's method to replace the package name with an empty String. As `replaceFirst` accepts a regular expression, the evaluation was more expensive. 
The new logic utilizes a simple substring search and doesn't create an unnecessary new String, but directly appends to the StringBuilder.

Additionally each dot (`.`) in the package's name, including the appended dot at the end, was treated as a wildcard, which is unexpected behaviour (i assume).