### PR TITLE
Unify reactor-core-micrometer version with reactor-core

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 version=3.8.0-SNAPSHOT
 bomVersion=2025.0.0-RC1
-metricsMicrometerVersion=1.3.0-SNAPSHOT
 
 org.gradle.parallel=true

--- a/reactor-core-micrometer/build.gradle
+++ b/reactor-core-micrometer/build.gradle
@@ -19,12 +19,9 @@ apply plugin: 'java-library'
 
 description = 'Reactor-Core Micrometer Metrics support'
 
-version = "$metricsMicrometerVersion"
 group = "io.projectreactor"
 
 ext {
-	def osgiVersion = osgiVersion("$metricsMicrometerVersion")
-
 	bndOptions = [
 		"Export-Package": [
 			"!*internal*",


### PR DESCRIPTION
Starting from **3.8.0**, the `reactor-core-micrometer` module will have the same version as reactor-core with which it is published.