### PR TITLE
Refine `Mono#doOnSuccess` `Consumer` nullability

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -5384,7 +5384,7 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	}
 
 	static <T> Mono<T> doOnTerminalSignal(Mono<T> source,
-			@Nullable Consumer<? super T> onSuccess,
+			@Nullable Consumer<? super @Nullable T> onSuccess,
 			@Nullable Consumer<? super Throwable> onError,
 			@Nullable BiConsumer<? super T, Throwable> onAfterTerminate) {
 		return onAssembly(new MonoPeekTerminal<>(source, onSuccess, onError, onAfterTerminate));

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoPeekTerminal.java
@@ -38,11 +38,13 @@ import reactor.core.Fuseable;
 final class MonoPeekTerminal<T> extends InternalMonoOperator<T, T> implements Fuseable {
 
 	final @Nullable BiConsumer<? super T, Throwable> onAfterTerminateCall;
-	final @Nullable Consumer<? super T>              onSuccessCall;
-	final @Nullable Consumer<? super Throwable>      onErrorCall;
+
+	final @Nullable Consumer<? super @Nullable T> onSuccessCall;
+
+	final @Nullable Consumer<? super Throwable> onErrorCall;
 
 	MonoPeekTerminal(Mono<? extends T> source,
-			@Nullable Consumer<? super T> onSuccessCall,
+			@Nullable Consumer<? super @Nullable T> onSuccessCall,
 			@Nullable Consumer<? super Throwable> onErrorCall,
 			@Nullable BiConsumer<? super T, Throwable> onAfterTerminateCall) {
 		super(source);


### PR DESCRIPTION
Since the operator delivers `null` as a result in case of an empty `Mono`, the `Consumer<? super T>` needs to change to allow nullable references. `Consumer<? super @Nullable T>` is the generic declaration that allows proper inference, especially by Kotlin, that the `Consumer`'s argument can be `null`.

Resolves #4151