### PR TITLE
fix: remove sun.misc for OSGi imports on Java 11 or newer

### DIFF
--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -394,6 +394,46 @@ jar {
 						  -exportcontents: io.micrometer.*
 						  '''.stripIndent()
 	}
+
+	// Remove sun.misc from versioned OSGi manifests (Java 11+).
+	// Java 11+ uses StackWalker instead of sun.misc, so the import is unnecessary.
+	// bnd generates versioned manifests automatically via JPMSMultiReleasePlugin but
+	// has no per-version Import-Package control, so we post-process the JAR.
+	doLast {
+		def jarFile = archiveFile.get().asFile
+		def jarUri = URI.create("jar:${jarFile.toURI()}")
+		def env = [create: 'false']
+
+		java.nio.file.FileSystems.newFileSystem(jarUri, env).withCloseable { fs ->
+			def versionsDir = fs.getPath('META-INF/versions')
+			if (!java.nio.file.Files.exists(versionsDir)) return
+
+			java.nio.file.Files.list(versionsDir).withCloseable { versions ->
+				versions.each { versionDir ->
+					def manifestPath = versionDir.resolve('OSGI-INF/MANIFEST.MF')
+					if (!java.nio.file.Files.exists(manifestPath)) return
+
+					def manifest = new java.util.jar.Manifest()
+					manifestPath.newInputStream().withCloseable { manifest.read(it) }
+
+					def importPkg = manifest.mainAttributes.getValue('Import-Package')
+					if (importPkg == null || !importPkg.contains('sun.misc')) return
+
+					// Remove sun.misc with optional directives (e.g. ;version="...";resolution:=optional)
+					def modified = importPkg
+						.replaceAll(',sun\\.misc(;[^,]*)?', '')
+						.replaceAll('sun\\.misc(;[^,]*)?,', '')
+						.replaceAll('sun\\.misc(;[^,]*)?', '')
+						.replaceAll(',\\s*$', '')
+
+					manifest.mainAttributes.putValue('Import-Package', modified)
+					manifestPath.newOutputStream().withCloseable { manifest.write(it) }
+
+					logger.lifecycle("Removed sun.misc from versioned manifest: ${manifestPath}")
+				}
+			}
+		}
+	}
 }
 
 jacocoTestReport.dependsOn test


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->
No longer require `sun.misc` in OSGi environments running Java 11 or newer.

<!-- Next paragraph contains more technical details -->
The `sun.misc` requirement is only mandatory for Java 8 but this was not reflected in the OSGi requirements,
leading to additional friction when deploying the bundle.

This change post-processes all multi-version manifests to no longer require `sun.misc`.

<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->


Fixes #3338