### PR TITLE
[#4230] FluxTakeUntilOther: Cancel main when other errors

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
@@ -114,7 +114,8 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 				return;
 			}
 			once = true;
-			main.onError(t);
+			//cancel main.main, and ensure that if this happens early an empty Subscription is passed down
+			main.cancelMainAndError(t);
 		}
 
 		@Override
@@ -181,6 +182,26 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 			Subscription s = this.main;
 			assert s != null : "main can not be null when requesting";
 			s.request(n);
+		}
+
+		void cancelMainAndError(Throwable t) {
+			Subscription s = main;
+			if (s != Operators.cancelledSubscription()) {
+				s = MAIN.getAndSet(this, Operators.cancelledSubscription());
+				if (s != null && s != Operators.cancelledSubscription()) {
+					s.cancel();
+				}
+
+				if (s == null) {
+					// this indicates the Other completed early, even before `main` was set.
+					// let's pass an empty Subscription down and complete immediately
+					Operators.error(actual, t);
+				}
+				else {
+					// if s wasn't null then Main Subscription was set and actual.onSubscribe already called
+					actual.onError(t);
+				}
+			}
 		}
 
 		void cancelMainAndComplete() {

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxTakeUntilOther.java
@@ -114,7 +114,8 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 				return;
 			}
 			once = true;
-			main.onError(t);
+			//cancel main.main, and ensure that if this happens early an empty Subscription is passed down
+			main.cancelMainAndError(t);
 		}
 
 		@Override
@@ -181,6 +182,26 @@ final class FluxTakeUntilOther<T, U> extends InternalFluxOperator<T, T> {
 			Subscription s = this.main;
 			assert s != null : "main can not be null when requesting";
 			s.request(n);
+		}
+
+		void cancelMainAndError(Throwable t) {
+			Subscription s = main;
+			if (s != Operators.cancelledSubscription()) {
+				s = MAIN.getAndSet(this, Operators.cancelledSubscription());
+				if (s != null && s != Operators.cancelledSubscription()) {
+					s.cancel();
+				}
+
+				if (s == null) {
+					// this indicates the Other errored early, even before `main` was set.
+					// let's pass an empty Subscription down and error immediately
+					Operators.error(actual, t);
+				}
+				else {
+					// if s wasn't null then Main Subscription was set and actual.onSubscribe already called
+					actual.onError(t);
+				}
+			}
 		}
 
 		void cancelMainAndComplete() {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxTakeUntilOtherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,13 +201,15 @@ public class FluxTakeUntilOtherTest {
 
 		Flux<Object> other =
 				Flux.error(new RuntimeException("forced " + "failure"))
+					.delaySubscription(Duration.ofMillis(1))
 				    .doOnCancel(() -> otherCancelled.set(true));
-		Flux.range(1, 10)
+		Flux.<Integer>never()
 		    .doOnCancel(() -> mainCancelled.set(true))
 		    .takeUntilOther(other)
 		    .subscribe(ts);
 
-		ts.assertNoValues()
+		ts.await()
+		  .assertNoValues()
 		  .assertNotComplete()
 		  .assertError(RuntimeException.class)
 		  .assertErrorMessage("forced failure");


### PR DESCRIPTION
<!-- What changes from the user's perspective? -->
Update FluxTakeUntilOther to cancel `main` if/when `other` errors


<!-- Next paragraph contains more technical details -->
Copy similar behavior of `other` completion to cancel `main` before emitting termination on `other` error. 

Fixes #4230 

