### PR TITLE
fix: return FAIL_CANCELLED from tryEmit* on auto-cancelled multicast sink

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyEmitterProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyEmitterProcessor.java
@@ -206,6 +206,9 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 
 	@Override
 	public EmitResult tryEmitComplete() {
+		if (isCancelled()) {
+			return EmitResult.FAIL_CANCELLED;
+		}
 		if (done) {
 			return EmitResult.FAIL_TERMINATED;
 		}
@@ -222,6 +225,9 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 	@Override
 	public EmitResult tryEmitError(Throwable t) {
 		Objects.requireNonNull(t, "tryEmitError must be invoked with a non-null Throwable");
+		if (isCancelled()) {
+			return EmitResult.FAIL_CANCELLED;
+		}
 		if (done) {
 			return EmitResult.FAIL_TERMINATED;
 		}
@@ -248,6 +254,9 @@ final class SinkManyEmitterProcessor<T> extends Flux<T> implements InternalManyS
 	public EmitResult tryEmitNext(T t) {
 		if (done) {
 			return Sinks.EmitResult.FAIL_TERMINATED;
+		}
+		if (isCancelled()) {
+			return EmitResult.FAIL_CANCELLED;
 		}
 
 		Objects.requireNonNull(t, "tryEmitNext must be invoked with a non-null value");

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyEmitterProcessorTest.java
@@ -923,4 +923,24 @@ class SinkManyEmitterProcessorTest {
 		            .expectTimeout(Duration.ofSeconds(1))
 		            .verify();
 	}
+
+	@Test
+	void autoCancelledSinkRejectsEmissions() {
+		// autoCancel is enabled by default — once all subscribers cancel, the sink shuts down
+		SinkManyEmitterProcessor<String> sink = new SinkManyEmitterProcessor<>(true, Queues.SMALL_BUFFER_SIZE);
+		reactor.core.Disposable subscription = sink.asFlux().subscribe(s -> {});
+		assertThat(sink.currentSubscriberCount()).isEqualTo(1);
+
+		assertThat(sink.tryEmitNext("before-cancel")).as("emit before cancel").isEqualTo(Sinks.EmitResult.OK);
+
+		subscription.dispose(); // triggers autoCancel — sink is now shut down
+		assertThat(sink.currentSubscriberCount()).as("subscriber count after cancel").isZero();
+
+		assertThat(sink.tryEmitNext("after-cancel")).as("tryEmitNext on cancelled sink should fail")
+				.isEqualTo(Sinks.EmitResult.FAIL_CANCELLED);
+		assertThat(sink.tryEmitError(new RuntimeException())).as("tryEmitError on cancelled sink should fail")
+				.isEqualTo(Sinks.EmitResult.FAIL_CANCELLED);
+		assertThat(sink.tryEmitComplete()).as("tryEmitComplete on cancelled sink should fail")
+				.isEqualTo(Sinks.EmitResult.FAIL_CANCELLED);
+	}
 }


### PR DESCRIPTION
## Summary

When all subscribers of a `Sinks.many().multicast().onBackpressureBuffer()` sink cancel and `autoCancel` is in effect, the sink transitions to a cancelled state. However, `tryEmitNext`, `tryEmitError`, and `tryEmitComplete` did not check `isCancelled()` before proceeding:

- `tryEmitNext` would still buffer elements once the queue was already allocated
- `tryEmitComplete` / `tryEmitError` would mark the sink as `done` and call `drain()` 

Since no subscriber will ever consume those signals after auto-cancel, accepting them gives a misleading `EmitResult.OK` return value. The Javadoc on `autoCancel` states: _"should the sink fully shutdowns (not publishing anymore) when the last subscriber cancels"_.

## Fix

Add `isCancelled()` guards at the beginning of all three `tryEmit*` methods:

```java
if (isCancelled()) {
    return EmitResult.FAIL_CANCELLED;
}
```

This is consistent with the intent documented for `autoCancel` and with how other terminal states are handled.

## Test

Added `autoCancelledSinkRejectsEmissions` verifying that after the last subscriber disposes:
- `tryEmitNext` returns `FAIL_CANCELLED`
- `tryEmitError` returns `FAIL_CANCELLED`
- `tryEmitComplete` returns `FAIL_CANCELLED`

Fixes #3715