### PR TITLE
[docs] Preserve nullability annotations in Javadoc

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+
 javadoc {
+	// Use a modern javadoc tool so TYPE_USE annotations (e.g. @Nullable) are
+	// rendered in method return type positions. Java 8's javadoc silently drops them
+	// due to https://bugs.openjdk.org/browse/JDK-8175390.
+	javadocTool = javaToolchains.javadocToolFor {
+		languageVersion = JavaLanguageVersion.of(21)
+	}
 	dependsOn jar
 	group = "documentation"
 	description = "Generates aggregated Javadoc API documentation."
@@ -28,12 +36,15 @@ javadoc {
 	options.memberLevel = JavadocMemberLevel.PROTECTED
 
 	if (project.name == "reactor-core") {
-		options.links([rootProject.jdkJavadoc, "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/"] as String[])
+		options.links([rootProject.jdkJavadoc,
+					   "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
+					   "https://javadoc.io/doc/org.jspecify/jspecify/${libs.versions.jspecify.get()}/"] as String[])
 	}
 	else {
 		options.links([rootProject.jdkJavadoc,
-									 "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
-									 "https://projectreactor.io/docs/core/release/api/"] as String[]);
+					   "https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/",
+					   "https://projectreactor.io/docs/core/release/api/",
+					   "https://javadoc.io/doc/org.jspecify/jspecify/${libs.versions.jspecify.get()}/"] as String[]);
 		//TODO add micrometer javadocs here
 		//tried to using javadoc.io but it is currently impossible to link to these from Javadoc JDK 8, no package-list
 	}

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -272,7 +272,11 @@ javadoc {
 	options.overview = "$rootDir/docs/api/overview.html"
 	excludes = [
 			// Must be public due to the ServiceLoader's requirements
-			"reactor/core/scheduler/ReactorBlockHoundIntegration.java"
+			"reactor/core/scheduler/ReactorBlockHoundIntegration.java",
+			// Java 8-specific implementation uses sun.misc.* which no longer exists in JDK 21+.
+			// The compiled class (Java 11+ version via multi-release jar) is on the classpath
+			// so references to it from other sources are still resolved correctly.
+			"reactor/core/publisher/CallSiteSupplierFactory.java"
 	]
 	doLast {
 		// work around https://github.com/gradle/gradle/issues/4046


### PR DESCRIPTION
Due to https://bugs.openjdk.org/browse/JDK-8175390 the `TYPE_USE` annotations are missing when Javadoc is generated with Java 8. This change uses a newer toolchain to generate Javadoc documentation and correctly links JSpecify's nullability annotations.

Resolves #4240 