### PR TITLE
Fix Operators.multiplyCap for zero operands

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -360,6 +360,9 @@ public abstract class Operators {
 	 * @return Product result or Long.MAX_VALUE if overflow
 	 */
 	public static long multiplyCap(long a, long b) {
+		if (a == 0 || b == 0) {
+			return 0;
+		}
 		long u = a * b;
 		if (((a | b) >>> 31) != 0) {
 			if (u / a != b) {

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -101,6 +101,14 @@ public class OperatorsTest {
 	}
 
 	@Test
+	public void multiplyCap() {
+		assertThat(Operators.multiplyCap(0, 1L << 31)).isZero();
+		assertThat(Operators.multiplyCap(1L << 31, 0)).isZero();
+		assertThat(Operators.multiplyCap(2, 3)).isEqualTo(6);
+		assertThat(Operators.multiplyCap(Long.MAX_VALUE, 2)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
 	public void constructor(){
 		assertThat(new Operators(){}).isNotNull();
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,14 @@ public class OperatorsTest {
 		assertThat(Operators.addCap(1, 2)).isEqualTo(3);
 		assertThat(Operators.addCap(1, Long.MAX_VALUE)).isEqualTo(Long.MAX_VALUE);
 		assertThat(Operators.addCap(0, -1)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void multiplyCap() {
+		assertThat(Operators.multiplyCap(0, 1L << 31)).isZero();
+		assertThat(Operators.multiplyCap(1L << 31, 0)).isZero();
+		assertThat(Operators.multiplyCap(2, 3)).isEqualTo(6);
+		assertThat(Operators.multiplyCap(Long.MAX_VALUE, 2)).isEqualTo(Long.MAX_VALUE);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #4269.

`Operators.multiplyCap(0, b)` could divide by zero during its overflow check when `b >= 2^31`. Returning zero before that check preserves the multiplication contract for either zero operand.

Verification:
- `./gradlew :reactor-core:test --no-daemon`
- `./gradlew spotlessCheck --no-daemon`
