### PR TITLE
Fix refCount cancellation before monitor setup

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -86,7 +86,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		inner.setRefCountMonitor(conn);
 
-		if (connect) {
+		if (connect && !RefCountInner.isCancelled(inner.state)) {
 			source.connect(conn);
 		}
 	}
@@ -178,6 +178,8 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		@Nullable Throwable error;
 
+		volatile boolean valueReceived;
+
 
 		static final int MONITOR_SET_FLAG = 0b0010_0000_0000_0000_0000_0000_0000_0000;
 		static final int TERMINATED_FLAG  = 0b0100_0000_0000_0000_0000_0000_0000_0000;
@@ -217,6 +219,9 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 				int previousState = this.state;
 
 				if (isCancelled(previousState)) {
+					if (!isMonitorSet(previousState) && !valueReceived) {
+						connection.innerCancelled();
+					}
 					return;
 				}
 
@@ -240,6 +245,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 
 		@Override
 		public void onNext(T t) {
+			valueReceived = true;
 			actual.onNext(t);
 		}
 
@@ -294,16 +300,22 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 		public void cancel() {
 			s.cancel();
 
-			int previousState = this.state;
+			for (;;) {
+				int previousState = this.state;
+				RefCountMonitor<T> connection = this.connection;
 
-			if (isTerminated(previousState) || isCancelled(previousState)) {
-				return;
-			}
+				if (connection == null || isTerminated(previousState) || isCancelled(previousState)) {
+					return;
+				}
 
-			if (isMonitorSet(previousState)
-					&& STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
-				assert connection != null : "isMonitorSet check guarantees connection is not null";
-				connection.innerCancelled();
+				int nextState = previousState | CANCELLED_FLAG;
+
+				if (STATE.compareAndSet(this, previousState, nextState)) {
+					if (isMonitorSet(previousState)) {
+						connection.innerCancelled();
+					}
+					return;
+				}
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCountGrace.java
@@ -97,7 +97,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		inner.setRefConnection(conn);
 
-		if (connect) {
+		if (connect && !RefCountInner.isCancelled(inner.state)) {
 			source.connect(conn);
 		}
 	}
@@ -207,6 +207,8 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		@Nullable Throwable error;
 
+		volatile boolean valueReceived;
+
 		static final int MONITOR_SET_FLAG = 0b0010_0000_0000_0000_0000_0000_0000_0000;
 		static final int TERMINATED_FLAG  = 0b0100_0000_0000_0000_0000_0000_0000_0000;
 		static final int CANCELLED_FLAG   = 0b1000_0000_0000_0000_0000_0000_0000_0000;
@@ -229,6 +231,9 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 				int previousState = this.state;
 
 				if (isCancelled(previousState)) {
+					if (!isMonitorSet(previousState) && !valueReceived) {
+						this.parent.cancel(connection);
+					}
 					return;
 				}
 
@@ -252,6 +257,7 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 
 		@Override
 		public void onNext(T t) {
+			valueReceived = true;
 			actual.onNext(t);
 		}
 
@@ -306,15 +312,22 @@ final class FluxRefCountGrace<T> extends Flux<T> implements Scannable, Fuseable 
 		public void cancel() {
 			s.cancel();
 
-			int previousState = this.state;
+			for (;;) {
+				int previousState = this.state;
+				RefConnection connection = this.connection;
 
-			if (isTerminated(previousState) || isCancelled(previousState)) {
-				return;
-			}
+				if (connection == null || isTerminated(previousState) || isCancelled(previousState)) {
+					return;
+				}
 
-			if (STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
-				assert connection != null : "connection must not be null when cancelling";
-				parent.cancel(connection);
+				int nextState = previousState | CANCELLED_FLAG;
+
+				if (STATE.compareAndSet(this, previousState, nextState)) {
+					if (isMonitorSet(previousState)) {
+						parent.cancel(connection);
+					}
+					return;
+				}
 			}
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountGraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.Scannable;
@@ -517,6 +518,22 @@ public class FluxRefCountGraceTest {
 
 		assertThat(test.scan(Scannable.Attr.ACTUAL)).isSameAs(actual);
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
+	}
+
+	@Test
+	public void cancelInOnSubscribeDecrementsRefCount() {
+		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {}, null, Subscription::cancel);
+		FluxRefCountGrace<Integer> parent = new FluxRefCountGrace<>(Flux.just(10).publish(), 1, Duration.ZERO, Schedulers.single());
+		FluxRefCountGrace.RefConnection connection = new FluxRefCountGrace.RefConnection(parent);
+		connection.subscriberCount = 1;
+		connection.connected = true;
+
+		FluxRefCountGrace.RefCountInner<Integer> test = new FluxRefCountGrace.RefCountInner<>(actual, parent);
+		test.onSubscribe(Operators.emptySubscription());
+		test.setRefConnection(connection);
+
+		assertThat(connection.subscriberCount).as("refCount subscribers").isZero();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("cancelled").isTrue();
 	}
 
 }

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -484,5 +484,41 @@ public class FluxRefCountTest {
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after cancel+onComplete").isTrue();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after cancel+onComplete").isFalse();
+	}
+
+	@Test
+	public void cancelInOnSubscribeDecrementsRefCount() {
+		CoreSubscriber<Integer> actual = new LambdaSubscriber<>(null, e -> {
+		}, null, Subscription::cancel);
+		FluxRefCount<Integer> main = new FluxRefCount<Integer>(Flux.just(10)
+																   .publish(), 1);
+		FluxRefCount.RefCountMonitor<Integer> connection = new FluxRefCount.RefCountMonitor<>(main);
+		connection.subscribers = 1;
+		connection.connected = true;
+
+		FluxRefCount.RefCountInner<Integer> test = new FluxRefCount.RefCountInner<Integer>(actual);
+		test.onSubscribe(Operators.emptySubscription());
+		test.setRefCountMonitor(connection);
+
+		assertThat(connection.subscribers).as("refCount subscribers").isZero();
+		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("cancelled").isTrue();
+	}
+
+	@Test
+	public void cancelInOnSubscribeDisconnectsSource() {
+		AtomicLong subscriptionCount = new AtomicLong();
+		AtomicReference<SignalType> termination = new AtomicReference<>();
+
+		Flux<Integer> refCounted = Flux.<Integer>never()
+		                               .doOnSubscribe(s -> subscriptionCount.incrementAndGet())
+		                               .doFinally(termination::set)
+		                               .publish()
+		                               .refCount(1);
+
+		refCounted.subscribe(new LambdaSubscriber<>(null, e -> {
+		}, null, Subscription::cancel));
+
+		assertThat(subscriptionCount).as("source subscriptions").hasValue(0);
+		assertThat(termination).as("source termination").hasValue(null);
 	}
 }


### PR DESCRIPTION
Avoid losing cancellation when a refCount subscriber cancels after the ref-count connection is assigned but before the monitor flag is set. This prevents a pre-connect subscriber from leaving the shared connection counted and connecting upstream after cancellation.

This covers both immediate and grace-period refCount paths, with regressions for `FluxRefCount` and `FluxRefCountGrace`.

Fixes #4289.

Testing:
- `./gradlew :reactor-core:test --tests reactor.core.publisher.FluxRefCountTest --tests reactor.core.publisher.FluxRefCountGraceTest --max-workers=2 --no-build-cache --rerun-tasks`
- `git diff --check HEAD~1..HEAD`

Breaking changes: None.