### PR TITLE
test: cover operators helper edge cases

### DIFF
--- a/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/OperatorsTest.java
@@ -1011,4 +1011,22 @@ public class OperatorsTest {
 	void emptySubscriberNotScannableStepName() {
 		assertThat(Scannable.from(Operators.emptySubscriber()).stepName()).isEqualTo("UNAVAILABLE_SCAN");
 	}
+
+	@Test
+	void multiplyCapReturnsProductOrLongMaxOnOverflow() {
+		assertThat(Operators.multiplyCap(12, 3)).isEqualTo(36);
+		assertThat(Operators.multiplyCap(1L << 32, 2)).isEqualTo(1L << 33);
+		assertThat(Operators.multiplyCap(Long.MAX_VALUE, 2)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
+	void discardQueueWithoutHookClearsQueue() {
+		Queue<Integer> queue = new ArrayBlockingQueue<>(3);
+		queue.add(1);
+		queue.add(2);
+
+		Operators.onDiscardQueueWithClear(queue, Context.empty(), null);
+
+		assertThat(queue).isEmpty();
+	}
 }


### PR DESCRIPTION
Hi,

I added two focused `OperatorsTest` cases for `Operators` helper behavior.

They check capped multiplication when products overflow, and the discard queue path that clears the queue when no discard hook is configured.

Covered lines include [`Operators.java:363-369`](https://github.com/reactor/reactor-core/blob/main/reactor-core/src/main/java/reactor/core/publisher/Operators.java#L363-L369), and [`Operators.java:468-475`](https://github.com/reactor/reactor-core/blob/main/reactor-core/src/main/java/reactor/core/publisher/Operators.java#L468-L475).
Branch coverage increases by about 3%.

No issue reference.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,