### PR TITLE
Fix replay history size validation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxReplay.java
@@ -62,6 +62,16 @@ final class FluxReplay<T> extends ConnectableFlux<T>
 
 	final @Nullable OptimizableOperator<?, T> optimizableOperator;
 
+	static void validateHistorySize(int historySize, boolean unbounded) {
+		if (historySize <= 0) {
+			throw new IllegalArgumentException("historySize must be strictly positive, was: " + historySize);
+		}
+		if (unbounded && historySize == Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("historySize must be less than Integer.MAX_VALUE for unbounded replay, " +
+					"was: " + historySize);
+		}
+	}
+
 	interface ReplaySubscription<T> extends QueueSubscription<T>, InnerProducer<T> {
 
 		@Override

--- a/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/ReplayProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * Create a new {@link ReplayProcessor} that replays up to {@code historySize}
 	 * elements.
 	 *
-	 * @param historySize the backlog size, ie. maximum items retained for replay.
+	 * @param historySize the backlog size, ie. maximum items retained for replay, must be strictly positive
 	 * @param <E> the type of the pushed elements
 	 *
 	 * @return a new {@link ReplayProcessor} that replays a limited history to each new
@@ -138,7 +138,8 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 * Create a new {@link ReplayProcessor} that either replay all the elements or a
 	 * limited amount of elements depending on the {@code unbounded} parameter.
 	 *
-	 * @param historySize maximum items retained if bounded, or initial link size if unbounded
+	 * @param historySize maximum items retained if bounded, or initial link size if unbounded;
+	 * must be strictly positive and, if unbounded, less than {@link Integer#MAX_VALUE}
 	 * @param unbounded true if "unlimited" data store must be supplied
 	 * @param <E> the type of the pushed elements
 	 *
@@ -150,6 +151,7 @@ public final class ReplayProcessor<T> extends FluxProcessor<T, T>
 	 */
 	@Deprecated
 	public static <E> ReplayProcessor<E> create(int historySize, boolean unbounded) {
+		FluxReplay.validateHistorySize(historySize, unbounded);
 		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
 			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ final class SinkManyReplayProcessor<T> extends Flux<T> implements InternalManySi
 	 * Create a new {@link SinkManyReplayProcessor} that replays up to {@code historySize}
 	 * elements.
 	 *
-	 * @param historySize the backlog size, ie. maximum items retained for replay.
+	 * @param historySize the backlog size, ie. maximum items retained for replay, must be strictly positive
 	 * @param <E> the type of the pushed elements
 	 *
 	 * @return a new {@link SinkManyReplayProcessor} that replays a limited history to each new
@@ -124,7 +124,8 @@ final class SinkManyReplayProcessor<T> extends Flux<T> implements InternalManySi
 	 * Create a new {@link SinkManyReplayProcessor} that either replay all the elements or a
 	 * limited amount of elements depending on the {@code unbounded} parameter.
 	 *
-	 * @param historySize maximum items retained if bounded, or initial link size if unbounded
+	 * @param historySize maximum items retained if bounded, or initial link size if unbounded;
+	 * must be strictly positive and, if unbounded, less than {@link Integer#MAX_VALUE}
 	 * @param unbounded true if "unlimited" data store must be supplied
 	 * @param <E> the type of the pushed elements
 	 *
@@ -132,6 +133,7 @@ final class SinkManyReplayProcessor<T> extends Flux<T> implements InternalManySi
 	 * {@link Subscriber} if configured as unbounded, a limited history otherwise.
 	 */
 	static <E> SinkManyReplayProcessor<E> create(int historySize, boolean unbounded) {
+		FluxReplay.validateHistorySize(historySize, unbounded);
 		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
 			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);

--- a/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinkManyReplayProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,6 +132,7 @@ final class SinkManyReplayProcessor<T> extends Flux<T> implements InternalManySi
 	 * {@link Subscriber} if configured as unbounded, a limited history otherwise.
 	 */
 	static <E> SinkManyReplayProcessor<E> create(int historySize, boolean unbounded) {
+		FluxReplay.validateHistorySize(historySize, unbounded);
 		FluxReplay.ReplayBuffer<E> buffer;
 		if (unbounded) {
 			buffer = new FluxReplay.UnboundedReplayBuffer<>(historySize);

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -625,7 +625,8 @@ public final class Sinks {
 		 *     <li>Backpressure : this sink honors downstream demand of individual subscribers.</li>
 		 *     <li>Replaying: all elements pushed to this sink are replayed to new subscribers.</li>
 		 * </ul>
-		 * @param batchSize the underlying buffer will optimize storage by linked arrays of given size
+		 * @param batchSize the linked array size used by the underlying buffer, must be strictly
+		 * positive and less than {@link Integer#MAX_VALUE}
 		 */
 		<T> Sinks.Many<T> all(int batchSize);
 

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -34,6 +34,15 @@ final class SinksSpecs {
 	static final Sinks.RootSpec  UNSAFE_ROOT_SPEC = new UnsafeSpecImpl();
 	static final DefaultSinksSpecs DEFAULT_SINKS    = new DefaultSinksSpecs();
 
+	static void validateReplayAllBatchSize(int batchSize) {
+		if (batchSize <= 0) {
+			throw new IllegalArgumentException("batchSize must be strictly positive, was: " + batchSize);
+		}
+		if (batchSize == Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("batchSize must be less than Integer.MAX_VALUE, was: " + batchSize);
+		}
+	}
+
 	abstract static class AbstractSerializedSink {
 
 		volatile int                                                   wip;
@@ -141,6 +150,7 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> all(int batchSize) {
+			validateReplayAllBatchSize(batchSize);
 			return SinkManyReplayProcessor.create(batchSize);
 		}
 
@@ -275,6 +285,7 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> all(int batchSize) {
+			validateReplayAllBatchSize(batchSize);
 			final SinkManyReplayProcessor<T> original = SinkManyReplayProcessor.create(batchSize, true);
 			return wrapMany(original);
 		}

--- a/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/SinksSpecs.java
@@ -141,6 +141,7 @@ final class SinksSpecs {
 
 		@Override
 		public <T> Many<T> all(int batchSize) {
+			FluxReplay.validateHistorySize(batchSize, true);
 			return SinkManyReplayProcessor.create(batchSize);
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyReplayProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyReplayProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -639,6 +639,51 @@ public class SinkManyReplayProcessorTest {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			SinkManyReplayProcessor.create(-1);
 		});
+	}
+
+	@Test
+	public void failZeroBufferSizeBounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(0);
+		}).withMessage("historySize must be strictly positive, was: 0");
+	}
+
+	@Test
+	public void failInvalidBufferSizeReplayProcessorBounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(0);
+		}).withMessage("historySize must be strictly positive, was: 0");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(-1);
+		}).withMessage("historySize must be strictly positive, was: -1");
+	}
+
+	@Test
+	public void failInvalidBufferSizeUnbounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(0, true);
+		}).withMessage("historySize must be strictly positive, was: 0");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(-1, true);
+		}).withMessage("historySize must be strictly positive, was: -1");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(Integer.MAX_VALUE, true);
+		}).withMessage("historySize must be less than Integer.MAX_VALUE for unbounded replay, " +
+				"was: 2147483647");
+	}
+
+	@Test
+	public void failInvalidBufferSizeReplayProcessorUnbounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(0, true);
+		}).withMessage("historySize must be strictly positive, was: 0");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(-1, true);
+		}).withMessage("historySize must be strictly positive, was: -1");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(Integer.MAX_VALUE, true);
+		}).withMessage("historySize must be less than Integer.MAX_VALUE for unbounded replay, " +
+				"was: 2147483647");
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/SinkManyReplayProcessorTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinkManyReplayProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -638,6 +638,26 @@ public class SinkManyReplayProcessorTest {
 	public void failNegativeBufferSizeBounded() {
 		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
 			SinkManyReplayProcessor.create(-1);
+		});
+	}
+
+	@Test
+	public void failZeroBufferSizeBounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(0);
+		});
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(0);
+		});
+	}
+
+	@Test
+	public void failMaximumBufferSizeUnbounded() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			SinkManyReplayProcessor.create(Integer.MAX_VALUE, true);
+		});
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
+			ReplayProcessor.create(Integer.MAX_VALUE, true);
 		});
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,30 @@ class SinksTest {
 	class MulticastReplayAll {
 
 		final Supplier<Sinks.Many<Integer>> supplier = () -> Sinks.many().replay().all();
+
+		@Test
+		void allInvalidBatchSizeIsRejected() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().all(0))
+				.withMessage("batchSize must be strictly positive, was: 0");
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.unsafe().many().replay().all(0))
+				.withMessage("batchSize must be strictly positive, was: 0");
+
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().all(-1))
+				.withMessage("batchSize must be strictly positive, was: -1");
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.unsafe().many().replay().all(-1))
+				.withMessage("batchSize must be strictly positive, was: -1");
+
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().all(Integer.MAX_VALUE))
+				.withMessage("batchSize must be less than Integer.MAX_VALUE, was: 2147483647");
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.unsafe().many().replay().all(Integer.MAX_VALUE))
+				.withMessage("batchSize must be less than Integer.MAX_VALUE, was: 2147483647");
+		}
 
 		@TestFactory
 		Stream<DynamicContainer> checkSemantics() {

--- a/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/SinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,19 @@ class SinksTest {
 	class MulticastReplayAll {
 
 		final Supplier<Sinks.Many<Integer>> supplier = () -> Sinks.many().replay().all();
+
+		@Test
+		void allInvalidBatchSizeIsRejected() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().all(0));
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.unsafe().many().replay().all(0));
+
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.many().replay().all(Integer.MAX_VALUE));
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> Sinks.unsafe().many().replay().all(Integer.MAX_VALUE));
+		}
 
 		@TestFactory
 		Stream<DynamicContainer> checkSemantics() {


### PR DESCRIPTION
Invalid replay sizes could reach buffer construction and surface as low-level failures such as `NegativeArraySizeException`. This validates non-positive history sizes and the overflowing `Integer.MAX_VALUE` unbounded size at the shared replay creation paths.

Focused tests cover the public replay sink variants and both processor creation paths.

Verification:
- `./gradlew :reactor-core:test --no-daemon`
- `./gradlew spotlessCheck --no-daemon`

Fixes #4274.
