### PR TITLE
Fix flatMap request accounting for resumed errors

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFlatMap.java
@@ -411,10 +411,7 @@ final class FluxFlatMap<T, R> extends InternalFluxOperator<T, R> {
 					Context ctx = actual.currentContext();
 					//does the strategy apply? if so, short-circuit the delayError. In any case, don't cancel
 					Throwable e_ = Operators.onNextError(t, e, ctx);
-					if (e_ == null) {
-						tryEmitScalar(null);
-					}
-					else if (!delayError || !Exceptions.addThrowable(ERROR, this, e_)) {
+					if (e_ != null && (!delayError || !Exceptions.addThrowable(ERROR, this, e_))) {
 					//now if error mode strategy doesn't apply, let delayError play
 						onError(Operators.onOperatorError(s, e_, t, ctx));
 					}
@@ -1173,4 +1170,3 @@ abstract class FlatMapTracker<T> {
 		return size == 0;
 	}
 }
-

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFlatMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
@@ -1639,6 +1640,41 @@ public class FluxFlatMapTest {
 				.verifyThenAssertThat()
 				.hasDropped(1)
 				.hasDroppedErrors(1);
+	}
+
+	@Test
+	public void errorModeContinueWithCallableDoesNotOverRequest() {
+		AtomicLong requested = new AtomicLong();
+		AtomicReference<Subscriber<? super Integer>> upstream = new AtomicReference<>();
+
+		Flux<Integer> test = Flux.from(s -> {
+					upstream.set(s);
+					s.onSubscribe(new Subscription() {
+						@Override
+						public void request(long n) {
+							requested.addAndGet(n);
+						}
+
+						@Override
+						public void cancel() {
+						}
+					});
+				})
+				.flatMap(f -> Mono.<Integer>fromCallable(() -> {
+					throw new IllegalStateException("boom");
+				}), 4)
+				.onErrorContinue(OnNextFailureStrategyTest::drop);
+
+		StepVerifier.create(test, 0)
+		            .then(() -> assertThat(requested).hasValue(4))
+		            .then(() -> upstream.get().onNext(1))
+		            .then(() -> upstream.get().onNext(2))
+		            .then(() -> assertThat(requested).hasValue(4))
+		            .then(() -> upstream.get().onComplete())
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasDropped(1, 2)
+		            .hasDroppedErrors(2);
 	}
 
 	@Test


### PR DESCRIPTION
**Fix details**

`Flux.flatMap` no longer over-requests from upstream when a `Callable` inner source throws and the error is resumed by `onErrorContinue`.

The `Callable` error path now accounts for the skipped source value once through the common post-error bookkeeping path, while preserving delayed-error behavior for errors that are not resumed. The regression test verifies that two resumed `Callable` failures do not trigger early upstream replenishment.

Tests:
- `./gradlew :reactor-core:test --tests reactor.core.publisher.FluxFlatMapTest --tests reactor.core.publisher.OnNextFailureStrategyTest --max-workers=2 --no-build-cache --rerun-tasks`
- `./gradlew spotlessCheck --max-workers=2 --no-build-cache`

Fixes #4290.