### PR TITLE
Validate bufferSize and prefetch bounds

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxFilterWhen.java
@@ -60,6 +60,7 @@ class FluxFilterWhen<T> extends InternalFluxOperator<T, T> {
 			Function<? super T, ? extends Publisher<Boolean>> asyncPredicate,
 			int bufferSize) {
 		super(source);
+		Operators.validateBufferSize(bufferSize);
 		this.asyncPredicate = asyncPredicate;
 		this.bufferSize = bufferSize;
 	}

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -65,9 +65,7 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			Supplier<? extends Queue<V>> groupQueueSupplier,
 			int prefetch) {
 		super(source);
-		if (prefetch <= 0) {
-			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
-		}
+		Operators.validateQueuePrefetch(prefetch);
 		this.keySelector = Objects.requireNonNull(keySelector, "keySelector");
 		this.valueSelector = Objects.requireNonNull(valueSelector, "valueSelector");
 		this.mainQueueSupplier =

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxSwitchMap.java
@@ -62,10 +62,7 @@ final class FluxSwitchMap<T, R> extends InternalFluxOperator<T, R> {
 			Supplier<? extends Queue<Object>> queueSupplier,
 			int prefetch) {
 		super(source);
-		if (prefetch <= 0) {
-			throw new IllegalArgumentException("prefetch > 0 required but it was " +
-					prefetch);
-		}
+		Operators.validateQueuePrefetch(prefetch);
 		this.mapper = Objects.requireNonNull(mapper, "mapper");
 		this.queueSupplier = Objects.requireNonNull(queueSupplier, "queueSupplier");
 		this.prefetch = prefetch;

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowPredicate.java
@@ -77,9 +77,7 @@ final class FluxWindowPredicate<T> extends InternalFluxOperator<T, Flux<T>>
 			Predicate<? super T> predicate,
 			Mode mode) {
 		super(Flux.from(source));
-		if (prefetch <= 0) {
-			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
-		}
+		Operators.validateQueuePrefetch(prefetch);
 		this.predicate = Objects.requireNonNull(predicate, "predicate");
 		this.mainQueueSupplier =
 				Objects.requireNonNull(mainQueueSupplier, "mainQueueSupplier");

--- a/reactor-core/src/main/java/reactor/core/publisher/Operators.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Operators.java
@@ -1508,6 +1508,25 @@ public abstract class Operators {
 		return prefetch == Integer.MAX_VALUE ? Long.MAX_VALUE : prefetch;
 	}
 
+	static final int MAX_SAFE_BUFFER_SIZE = 1 << 30;
+
+	static void validateBufferSize(int bufferSize) {
+		if (bufferSize <= 0 || bufferSize > MAX_SAFE_BUFFER_SIZE) {
+			throw new IllegalArgumentException("bufferSize > 0 and <= " +
+					MAX_SAFE_BUFFER_SIZE + " required but it was " + bufferSize);
+		}
+	}
+
+	static void validateQueuePrefetch(int prefetch) {
+		if (prefetch <= 0) {
+			throw new IllegalArgumentException("prefetch > 0 required but it was " + prefetch);
+		}
+		if (prefetch > MAX_SAFE_BUFFER_SIZE && prefetch != Integer.MAX_VALUE) {
+			throw new IllegalArgumentException("prefetch > 0 and <= " +
+					MAX_SAFE_BUFFER_SIZE + " or Integer.MAX_VALUE required but it was " + prefetch);
+		}
+	}
+
 	static int unboundedOrLimit(int prefetch) {
 		return prefetch == Integer.MAX_VALUE ? Integer.MAX_VALUE : (prefetch - (prefetch >>	2));
 	}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxFilterWhenTest {
 
@@ -332,6 +333,30 @@ public class FluxFilterWhenTest {
 		    .subscribe().dispose();
 
 		assertThat(requested).hasValue(bufferSize);
+	}
+
+	@Test
+	public void bufferSizeMustBeStrictlyPositive() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), 0))
+				.withMessage("bufferSize > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE + " required but it was 0");
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), -1))
+				.withMessage("bufferSize > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE + " required but it was -1");
+	}
+
+	@Test
+	public void bufferSizeMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("bufferSize > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE + " required but it was " +
+						(Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), Integer.MAX_VALUE))
+				.withMessage("bufferSize > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE + " required but it was " +
+						Integer.MAX_VALUE);
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxFilterWhenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.TestPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class FluxFilterWhenTest {
 
@@ -332,6 +333,15 @@ public class FluxFilterWhenTest {
 		    .subscribe().dispose();
 
 		assertThat(requested).hasValue(bufferSize);
+	}
+
+	@Test
+	public void bufferSizeMustBeWithinSafeBounds() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), 0));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).filterWhen(v -> Mono.just(true), Operators.MAX_SAFE_BUFFER_SIZE + 1));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
 public class FluxGroupByTest extends
@@ -930,6 +931,19 @@ public class FluxGroupByTest extends
 		            .verifyComplete();
 
 		assertThat(initialRequest).hasValue(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void prefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.range(1, 10).groupBy(i -> i % 5, Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.range(1, 10).groupBy(i -> i % 5, Integer.MAX_VALUE - 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Integer.MAX_VALUE - 1));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import reactor.test.subscriber.AssertSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
 public class FluxGroupByTest extends
@@ -930,6 +931,12 @@ public class FluxGroupByTest extends
 		            .verifyComplete();
 
 		assertThat(initialRequest).hasValue(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void prefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.range(1, 10).groupBy(i -> i % 5, Operators.MAX_SAFE_BUFFER_SIZE + 1));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,11 +34,13 @@ import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.ParameterizedTestWithName;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 import reactor.test.subscriber.TestSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 import static reactor.core.publisher.Sinks.EmitResult.FAIL_OVERFLOW;
 
@@ -360,6 +362,45 @@ public class FluxSwitchMapTest {
 		StepVerifier.create(Flux.switchOnNext(up.asFlux(), prefetch))
 		            .expectNext(1, 2, 3, 2, 3, 4, 4, 5, 6)
 		            .verifyComplete();
+	}
+
+	@Test
+	public void switchMapPrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).switchMap(i -> Flux.just(i), Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).switchMap(i -> Flux.just(i), Integer.MAX_VALUE - 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Integer.MAX_VALUE - 1));
+	}
+
+	@Test
+	public void switchOnNextPrefetchMustNotExceedMaximumSafeCapacity() {
+		Flux<Flux<Integer>> source = Flux.just(Flux.just(1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.switchOnNext(source, Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.switchOnNext(source, Integer.MAX_VALUE - 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Integer.MAX_VALUE - 1));
+	}
+
+	@Test
+	public void switchOnNextPrefetchIntegerMaxRequestsUnbounded() {
+		TestPublisher<Flux<Integer>> outer = TestPublisher.create();
+		TestPublisher<Integer> inner = TestPublisher.create();
+
+		Flux.switchOnNext(outer.flux(), Integer.MAX_VALUE).subscribe();
+
+		outer.emit(inner.flux());
+		inner.assertMinRequested(Long.MAX_VALUE);
 	}
 
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxSwitchMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import reactor.test.subscriber.TestSubscriber;
 import reactor.util.concurrent.Queues;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 import static reactor.core.publisher.Sinks.EmitResult.FAIL_OVERFLOW;
 
@@ -359,6 +360,27 @@ public class FluxSwitchMapTest {
 		up.emitComplete(FAIL_FAST);
 		StepVerifier.create(Flux.switchOnNext(up.asFlux(), prefetch))
 		            .expectNext(1, 2, 3, 2, 3, 4, 4, 5, 6)
+		            .verifyComplete();
+	}
+
+	@Test
+	public void switchMapPrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).switchMap(i -> Flux.just(i), Operators.MAX_SAFE_BUFFER_SIZE + 1));
+	}
+
+	@Test
+	public void switchOnNextPrefetchMustNotExceedMaximumSafeCapacity() {
+		Flux<Flux<Integer>> source = Flux.just(Flux.just(1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.switchOnNext(source, Operators.MAX_SAFE_BUFFER_SIZE + 1));
+	}
+
+	@Test
+	public void switchOnNextPrefetchIntegerMaxRemainsSupported() {
+		StepVerifier.create(Flux.switchOnNext(Flux.just(Flux.just(1)), Integer.MAX_VALUE))
+		            .expectNext(1)
 		            .verifyComplete();
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import reactor.util.context.Context;
 
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static reactor.core.publisher.SignalType.*;
@@ -924,6 +925,32 @@ public class FluxWindowPredicateTest extends
 		TestPublisher<?> tp = TestPublisher.create();
 		tp.flux().windowWhile(s -> true, Integer.MAX_VALUE).subscribe();
 		tp.assertMinRequested(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void windowUntilPrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowUntil(i -> true, true, Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowUntil(i -> true, true, Integer.MAX_VALUE - 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Integer.MAX_VALUE - 1));
+	}
+
+	@Test
+	public void windowWhilePrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowWhile(i -> true, Operators.MAX_SAFE_BUFFER_SIZE + 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Operators.MAX_SAFE_BUFFER_SIZE + 1));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowWhile(i -> true, Integer.MAX_VALUE - 1))
+				.withMessage("prefetch > 0 and <= " + Operators.MAX_SAFE_BUFFER_SIZE +
+						" or Integer.MAX_VALUE required but it was " + (Integer.MAX_VALUE - 1));
 	}
 
 	@Test

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowPredicateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import reactor.util.context.Context;
 
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static reactor.core.publisher.SignalType.*;
@@ -924,6 +925,18 @@ public class FluxWindowPredicateTest extends
 		TestPublisher<?> tp = TestPublisher.create();
 		tp.flux().windowWhile(s -> true, Integer.MAX_VALUE).subscribe();
 		tp.assertMinRequested(Long.MAX_VALUE);
+	}
+
+	@Test
+	public void windowUntilPrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowUntil(i -> true, true, Operators.MAX_SAFE_BUFFER_SIZE + 1));
+	}
+
+	@Test
+	public void windowWhilePrefetchMustNotExceedMaximumSafeCapacity() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> Flux.just(1).windowWhile(i -> true, Operators.MAX_SAFE_BUFFER_SIZE + 1));
 	}
 
 	@Test


### PR DESCRIPTION
Values greater than `1 << 30` overflow the internal power-of-two capacity calculation. This change validates `filterWhen` buffer sizes and queue-backed prefetch values before allocation, while preserving `Integer.MAX_VALUE` as the existing unbounded prefetch sentinel.

The affected public operators have focused boundary coverage, including the preserved unbounded behavior.

Verification:
- `./gradlew :reactor-core:test --no-daemon`
- `./gradlew spotlessCheck --no-daemon`

Fixes #4273.
