### PR TITLE
Fix trigger value discarding in FluxBufferPredicate (#4316)

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferPredicate.java
@@ -233,6 +233,7 @@ final class FluxBufferPredicate<T, C extends Collection<? super T>>
 				}
 			}
 			else if (mode == Mode.WHILE && !match) {
+				Operators.onDiscard(t, actual.currentContext());
 				onNextNewBuffer();
 			}
 			else {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferPredicateTest.java
@@ -1198,7 +1198,7 @@ public class FluxBufferPredicateTest {
 				RaceTestUtils.race(() -> subscriber.onNext(value2), subscriber::cancel);
 			}
 
-			Assertions.assertThat(value2).as("trigger value not discarded").hasValue(-2);
+			Assertions.assertThat(value2).as("trigger value should be discarded").hasValue(-1);
 
 			Assertions.assertThat(received.get() + (value1.get() + 1))
 					.as("received %d, val1 state %d", received.get(), value1.get())


### PR DESCRIPTION
Trigger value in FluxBufferPredicate is discarded according to the documentation. Also fix the test so that it checks the declared behavior

Fixes #4316

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
