### PR TITLE
Fix windowTimeout backpressure after timeout

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxWindowTimeout.java
@@ -140,6 +140,9 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 
 		@Nullable InnerWindow<T> window;
 
+		// Access is serialized through the parent drain loop.
+		long deferredRequest;
+
 		WindowTimeoutWithBackpressureSubscriber(CoreSubscriber<? super Flux<T>> actual,
 				int maxSize,
 				long timespan,
@@ -485,9 +488,9 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 								return;
 							}
 
-							final long nextRequest = InnerWindow.received(previousInnerWindowState);
-							if (nextRequest > 0) {
-								this.s.request(nextRequest);
+							this.deferredRequest += InnerWindow.received(previousInnerWindowState);
+							if (!shouldBeUnsent) {
+								requestDeferred();
 							}
 
 
@@ -495,6 +498,8 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 								return;
 							}
 						} else {
+							requestDeferred();
+
 							previousState = commitSent(this, expectedState);
 							expectedState = (previousState &~ HAS_UNSENT_WINDOW) ^ (expectedState == previousState ? HAS_WORK_IN_PROGRESS : 0);
 							previousState &= ~HAS_UNSENT_WINDOW;
@@ -585,9 +590,8 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 							nextRequest = InnerWindow.received(previousActiveWindowState);
 						}
 
-						if (nextRequest > 0) {
-							this.s.request(nextRequest);
-						}
+						this.deferredRequest += nextRequest;
+						requestDeferred();
 
 						if (!hasWorkInProgress(expectedState)) {
 							return;
@@ -640,9 +644,9 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 					long previousActiveWindowState = previousWindow.sendComplete();
 					final long nextRequest = InnerWindow.received(previousActiveWindowState);
 
-					if (nextRequest > 0) {
-						this.s.request(nextRequest);
-					}
+					// Keep the replenishment pending while the next window cannot be
+					// delivered. It is requested once downstream asks for that window.
+					this.deferredRequest += nextRequest;
 
 					if (!hasWorkInProgress(expectedState)) {
 						return;
@@ -679,6 +683,14 @@ final class FluxWindowTimeout<T> extends InternalFluxOperator<T, Flux<T>> {
 						return;
 					}
 				}
+			}
+		}
+
+		void requestDeferred() {
+			final long n = this.deferredRequest;
+			if (n > 0) {
+				this.deferredRequest = 0;
+				this.s.request(n);
 			}
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxWindowTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.LongStream;
 
@@ -42,6 +43,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FluxWindowTimeoutTest {
+
+	@Test
+	public void timeoutDoesNotReplenishWithoutDownstreamDemand() {
+		AtomicLong requested = new AtomicLong();
+		TestPublisher<Integer> source = TestPublisher.create();
+
+		StepVerifier.withVirtualTime(() -> source.flux()
+		                                      .doOnRequest(requested::addAndGet)
+		                                      .windowTimeout(10, Duration.ofSeconds(1), true),
+				1)
+		            .expectSubscription()
+		            .expectNextCount(1)
+		            .then(() -> source.next(1))
+		            .thenAwait(Duration.ofSeconds(1))
+		            .then(() -> assertThat(requested).hasValue(10))
+		            .thenAwait(Duration.ofSeconds(1))
+		            .thenRequest(1)
+		            .expectNextCount(1)
+		            .then(() -> assertThat(requested).hasValue(10))
+		            .thenRequest(1)
+		            .expectNextCount(1)
+		            .then(() -> assertThat(requested).hasValue(11))
+		            .thenCancel()
+		            .verify();
+	}
 
 	@Test
 	public void windowTimeoutWithBackPressureFromCore() throws InterruptedException {


### PR DESCRIPTION
When `windowTimeout(maxSize, duration, true)` closes a window because of a timeout, it now stops replenishing upstream demand if downstream has not requested the next window. This preserves backpressure for slow or temporarily unavailable downstream consumers.

Replenishment is deferred while a window remains pending and resumes when downstream requests that window. The deferred demand is managed within the existing serialized drain loop and cleared before requesting upstream to preserve reentrancy safety. A virtual-time regression test covers suspension across timeouts and subsequent demand resumption.

Fixes #4205.