### PR TITLE
Avoid starving virtual threads in sink failure handler

### DIFF
--- a/docs/modules/ROOT/pages/processors.adoc
+++ b/docs/modules/ROOT/pages/processors.adoc
@@ -71,6 +71,8 @@ EmitResult result = replaySink.tryEmitNext(4);
 When using the `busyLooping`, be aware that returned instances of `EmitFailureHandler` can not be reused, e.g.,
 it should be one call of `busyLooping` per `emitNext`.
 Also, it is recommended to use a timeout above 100ms since smaller values don’t make practical sense.
+The retry loop yields between attempts, allowing other platform threads or virtual threads that share
+the same carrier thread pool to make progress.
 ====
 
 The `Sinks.Many` can be presented to downstream consumers as a `Flux`, like in the below example:

--- a/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Sinks.java
@@ -236,8 +236,12 @@ public final class Sinks {
 
 		@Override
 		public boolean onEmitFailure(SignalType signalType, EmitResult emitResult) {
-			return emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED)
+			boolean shouldRetry = emitResult.equals(Sinks.EmitResult.FAIL_NON_SERIALIZED)
 					&& deadline - System.nanoTime() > 0; // difference is used to tackle a numeric overflow
+			if (shouldRetry) {
+				Thread.yield();
+			}
+			return shouldRetry;
 		}
 	}
 
@@ -262,8 +266,10 @@ public final class Sinks {
 		EmitFailureHandler FAIL_FAST = (signalType, emission) -> false;
 
 		/**
-		 * Create an {@link EmitFailureHandler} which will busy loop in case of concurrent use
+		 * Create an {@link EmitFailureHandler} which will loop and yield in case of concurrent use
 		 * of the sink ({@link EmitResult#FAIL_NON_SERIALIZED}, up to a deadline.
+		 * Yielding prevents the retry loop from monopolizing a platform thread or a virtual
+		 * thread's carrier thread while another thread completes an emission.
 		 * The deadline is computed immediately from the current time (construction time)
 		 * + provided {@link Duration}.
 		 * <p>

--- a/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/ReactorBlockHoundIntegration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ public final class ReactorBlockHoundIntegration implements BlockHoundIntegration
         // For now, let's not add a separate integration, but rather let's define the class name manually
         // ContextRegistry reads files as part of the Service Loader aspect. If class is initialized in a non-blocking thread, BlockHound would complain
         builder.allowBlockingCallsInside("reactor.core.publisher.ContextPropagation", "<clinit>");
+        builder.allowBlockingCallsInside("reactor.core.publisher.Sinks$OptimisticEmitFailureHandler", "onEmitFailure");
         builder.allowBlockingCallsInside(FutureTask.class.getName(),"handlePossibleCancellationInterrupt");
     }
 }

--- a/reactor-core/src/test/java21/reactor/core/publisher/SinksVirtualThreadTest.java
+++ b/reactor-core/src/test/java21/reactor/core/publisher/SinksVirtualThreadTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.publisher;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SinksVirtualThreadTest {
+
+	@Test
+	@Timeout(10)
+	void busyLoopingDoesNotStarveVirtualThreads() throws InterruptedException {
+		int carrierThreads = Runtime.getRuntime().availableProcessors();
+		Sinks.Many<String> sink = Sinks.many().multicast().directAllOrNothing();
+		CountDownLatch guardHeld = new CountDownLatch(1);
+		CountDownLatch releaseGuard = new CountDownLatch(1);
+		List<Thread> emitters = new ArrayList<>();
+
+		sink.asFlux().subscribe(value -> {
+			guardHeld.countDown();
+			try {
+				releaseGuard.await();
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		});
+
+		Thread guardHolder = Thread.ofPlatform().name("sink-guard-holder").start(() ->
+				sink.emitNext("guard", Sinks.EmitFailureHandler.FAIL_FAST));
+		assertThat(guardHeld.await(5, TimeUnit.SECONDS)).isTrue();
+
+		try {
+			for (int i = 0; i < carrierThreads; i++) {
+				emitters.add(Thread.ofVirtual().name("sink-busy-loop-" + i).start(() ->
+						sink.emitNext("value", Sinks.EmitFailureHandler.busyLooping(Duration.ofSeconds(5)))));
+			}
+
+			CountDownLatch probeRan = new CountDownLatch(1);
+			Thread.ofVirtual().name("sink-probe").start(probeRan::countDown);
+
+			assertThat(probeRan.await(2, TimeUnit.SECONDS)).isTrue();
+		}
+		finally {
+			releaseGuard.countDown();
+			guardHolder.join();
+			for (Thread emitter : emitters) {
+				emitter.join();
+			}
+		}
+	}
+}


### PR DESCRIPTION
`Sinks.EmitFailureHandler.busyLooping` no longer starves virtual threads that share the same carrier thread pool.

The built-in failure handler now calls `Thread.yield()` between retries of `FAIL_NON_SERIALIZED`. The intentional yield is allowed by Reactor's BlockHound integration. This also adds Java 21 regression coverage and documents the yielding behavior.

Fixes #4247.