### PR TITLE
fix Javadoc package-list compatibility

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -55,4 +55,17 @@ javadoc {
 	destinationDir = project.layout.buildDirectory.dir("docs/javadoc").get().asFile
 
 	options.addStringOption("Xdoclint:none", "-quiet")
+
+	doLast {
+		// JDK 9+ generates element-list, while JDK 8 Javadoc and older
+		// documentation tools still require package-list.
+		def elementList = new File(destinationDir, "element-list")
+		if (elementList.exists()) {
+			copy {
+				from elementList
+				into destinationDir
+				rename { "package-list" }
+			}
+		}
+	}
 }


### PR DESCRIPTION
<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->

Restores Javadoc linking compatibility for Java 8 and older documentation tools by including `package-list` in the generated Reactor Core and Reactor Test Javadocs.

<!-- Next paragraph contains more technical details -->

JDK 9 and later generate `element-list`, while Java 8 Javadoc and some Dokka versions still require `package-list`. After Javadoc generation, the build now copies `element-list` to `package-list`. Both files are included in the published Javadoc JARs.

<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
Fixes #4278.

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->