### PR TITLE
Fix onErrorContinue consumer nullability

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -7190,11 +7190,11 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * and cannot leak upstream.
 	 *
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the predicate and the value
-	 * that triggered the error.
+	 * that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Flux} that attempts to continue processing on errors.
 	 */
-	public final Flux<T> onErrorContinue(BiConsumer<Throwable, Object> errorConsumer) {
-		BiConsumer<Throwable, Object> genericConsumer = errorConsumer;
+	public final Flux<T> onErrorContinue(BiConsumer<Throwable, @Nullable Object> errorConsumer) {
+		BiConsumer<Throwable, @Nullable Object> genericConsumer = errorConsumer;
 		return contextWriteSkippingContextPropagation(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resume(genericConsumer)
@@ -7231,10 +7231,10 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * @param type the {@link Class} of {@link Exception} that are resumed from.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
-	 * and the value that triggered the error.
+	 * and the value that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Flux} that attempts to continue processing on some errors.
 	 */
-	public final <E extends Throwable> Flux<T> onErrorContinue(Class<E> type, BiConsumer<Throwable, Object> errorConsumer) {
+	public final <E extends Throwable> Flux<T> onErrorContinue(Class<E> type, BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		return onErrorContinue(type::isInstance, errorConsumer);
 	}
 
@@ -7270,15 +7270,15 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * @param errorPredicate a {@link Predicate} used to filter which errors should be resumed from.
 	 * This MUST be idempotent, as it can be used several times.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the predicate and the value
-	 * that triggered the error.
+	 * that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Flux} that attempts to continue processing on some errors.
 	 */
 	public final <E extends Throwable> Flux<T> onErrorContinue(Predicate<E> errorPredicate,
-			BiConsumer<Throwable, Object> errorConsumer) {
+			BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		//this cast is ok as only T values will be propagated in this sequence
 		@SuppressWarnings("unchecked")
 		Predicate<Throwable> genericPredicate = (Predicate<Throwable>) errorPredicate;
-		BiConsumer<Throwable, Object> genericErrorConsumer = errorConsumer;
+		BiConsumer<Throwable, @Nullable Object> genericErrorConsumer = errorConsumer;
 		return contextWriteSkippingContextPropagation(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resumeIf(genericPredicate, genericErrorConsumer)

--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -3708,11 +3708,11 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * and cannot leak upstream.
 	 *
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
-	 * and the value that triggered the error.
+	 * and the value that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Mono} that attempts to continue processing on errors.
 	 */
-	public final Mono<T> onErrorContinue(BiConsumer<Throwable, Object> errorConsumer) {
-		BiConsumer<Throwable, Object> genericConsumer = errorConsumer;
+	public final Mono<T> onErrorContinue(BiConsumer<Throwable, @Nullable Object> errorConsumer) {
+		BiConsumer<Throwable, @Nullable Object> genericConsumer = errorConsumer;
 		return contextWriteSkippingContextPropagation(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resume(genericConsumer)
@@ -3752,10 +3752,10 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 *
 	 * @param type the {@link Class} of {@link Exception} that are resumed from.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the {@link Class}
-	 * and the value that triggered the error.
+	 * and the value that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Mono} that attempts to continue processing on some errors.
 	 */
-	public final <E extends Throwable> Mono<T> onErrorContinue(Class<E> type, BiConsumer<Throwable, Object> errorConsumer) {
+	public final <E extends Throwable> Mono<T> onErrorContinue(Class<E> type, BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		return onErrorContinue(type::isInstance, errorConsumer);
 	}
 
@@ -3794,15 +3794,15 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * @param errorPredicate a {@link Predicate} used to filter which errors should be resumed from.
 	 * This MUST be idempotent, as it can be used several times.
 	 * @param errorConsumer a {@link BiConsumer} fed with errors matching the predicate and the value
-	 * that triggered the error.
+	 * that triggered the error, or {@code null} if the error is not associated with a value.
 	 * @return a {@link Mono} that attempts to continue processing on some errors.
 	 */
 	public final <E extends Throwable> Mono<T> onErrorContinue(Predicate<E> errorPredicate,
-			BiConsumer<Throwable, Object> errorConsumer) {
+			BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		//this cast is ok as only T values will be propagated in this sequence
 		@SuppressWarnings("unchecked")
 		Predicate<Throwable> genericPredicate = (Predicate<Throwable>) errorPredicate;
-		BiConsumer<Throwable, Object> genericErrorConsumer = errorConsumer;
+		BiConsumer<Throwable, @Nullable Object> genericErrorConsumer = errorConsumer;
 		return contextWriteSkippingContextPropagation(Context.of(
 				OnNextFailureStrategy.KEY_ON_NEXT_ERROR_STRATEGY,
 				OnNextFailureStrategy.resumeIf(genericPredicate, genericErrorConsumer)

--- a/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/OnNextFailureStrategy.java
@@ -115,7 +115,7 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 	 * It must deal with potential {@code null}s.
 	 * @return a new {@link OnNextFailureStrategy} that allows resuming the sequence.
 	 */
-	static OnNextFailureStrategy resume(BiConsumer<Throwable, Object> errorConsumer) {
+	static OnNextFailureStrategy resume(BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		return new ResumeStrategy(null, errorConsumer);
 	}
 
@@ -136,7 +136,7 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 	 */
 	static OnNextFailureStrategy resumeIf(
 			Predicate<Throwable> causePredicate,
-			BiConsumer<Throwable, Object> errorConsumer) {
+			BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 		return new ResumeStrategy(causePredicate, errorConsumer);
 	}
 
@@ -162,10 +162,10 @@ interface OnNextFailureStrategy extends BiFunction<Throwable, Object, Throwable>
 	final class ResumeStrategy implements OnNextFailureStrategy {
 
 		final @Nullable Predicate<Throwable>  errorPredicate;
-		final BiConsumer<Throwable, Object>   errorConsumer;
+		final BiConsumer<Throwable, @Nullable Object> errorConsumer;
 
 		ResumeStrategy(@Nullable Predicate<Throwable> errorPredicate,
-					   BiConsumer<Throwable, Object> errorConsumer) {
+					   BiConsumer<Throwable, @Nullable Object> errorConsumer) {
 			this.errorPredicate = errorPredicate;
 			this.errorConsumer = errorConsumer;
 		}


### PR DESCRIPTION
Kotlin consumers of `Flux#onErrorContinue` and `Mono#onErrorContinue` now correctly infer that the value associated with an error can be nullable.

Annotate the second `BiConsumer` type argument with JSpecify's `@Nullable` across all `onErrorContinue` overloads and the internal `OnNextFailureStrategy`. This aligns the public nullability contract with existing behavior when an error has no associated upstream value. The Javadocs now explicitly document this case.

Fixes #4285.