### PR TITLE
Fix integer overflow in bufferTimeout fair backpressure prefetch

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,8 +212,8 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 			this.bufferSupplier = bufferSupplier;
 			this.logger = logger;
 			this.stateLogger = logger != null ? new StateLogger(logger) : null;
-			this.prefetch = batchSize << 2;
-			this.replenishMark = batchSize << 1;
+			this.prefetch = (int) Math.min((long) batchSize << 2, Integer.MAX_VALUE);
+			this.replenishMark = (int) Math.min((long) batchSize << 1, Integer.MAX_VALUE);
 			this.queue = Queues.<T>get(prefetch).get();
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutFairBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutFairBackpressureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -470,5 +470,60 @@ public class FluxBufferTimeoutFairBackpressureTest {
 		            .assertNext(l -> assertThat(l).containsExactly(1, 2, 3))
 		            .expectErrorMessage("boom")
 		            .verify();
+	}
+
+	// see https://github.com/reactor/reactor-core/issues/4185
+	@Test
+	public void largeBatchSizeDoesNotOverflowPrefetch() {
+		CoreSubscriber<List<Integer>> actual = new LambdaSubscriber<>(null, e -> {}, null, null);
+		Scheduler.Worker worker = Schedulers.immediate().createWorker();
+
+		try {
+			int overflowBatchSize = (Integer.MAX_VALUE >> 2) + 1;
+			FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>> atBoundary =
+					new FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>>(
+							actual, overflowBatchSize, 1000, TimeUnit.MILLISECONDS,
+							worker, ArrayList::new, null
+					);
+			assertThat(atBoundary.scan(Scannable.Attr.CAPACITY)).isEqualTo(Integer.MAX_VALUE);
+
+			FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>> unbounded =
+					new FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>>(
+							actual, Integer.MAX_VALUE, 1000, TimeUnit.MILLISECONDS,
+							worker, ArrayList::new, null
+					);
+			assertThat(unbounded.scan(Scannable.Attr.CAPACITY)).isEqualTo(Integer.MAX_VALUE);
+
+			int safeBatchSize = Integer.MAX_VALUE >> 2;
+			FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>> safe =
+					new FluxBufferTimeout.BufferTimeoutWithBackpressureSubscriber<Integer, List<Integer>>(
+							actual, safeBatchSize, 1000, TimeUnit.MILLISECONDS,
+							worker, ArrayList::new, null
+					);
+			assertThat(safe.scan(Scannable.Attr.CAPACITY)).isEqualTo(safeBatchSize << 2);
+		}
+		finally {
+			worker.dispose();
+		}
+	}
+
+	// see https://github.com/reactor/reactor-core/issues/4185
+	@Test
+	public void bufferTimeoutWithIntegerMaxSizeDoesNotHang() {
+		AtomicLong upstreamRequested = new AtomicLong();
+		VirtualTimeScheduler scheduler = VirtualTimeScheduler.create();
+
+		StepVerifier.withVirtualTime(
+				() -> Flux.just(1, 2, 3)
+				          .doOnRequest(upstreamRequested::addAndGet)
+				          .bufferTimeout(Integer.MAX_VALUE, Duration.ofMillis(100), scheduler, true),
+				() -> scheduler,
+				1
+		)
+		            .expectSubscription()
+		            .then(() -> assertThat(upstreamRequested.get()).isGreaterThan(0))
+		            .thenAwait(Duration.ofMillis(100))
+		            .assertNext(list -> assertThat(list).containsExactly(1, 2, 3))
+		            .verifyComplete();
 	}
 }


### PR DESCRIPTION
Fixes #4185

### What was wrong

With `fairBackpressure = true`, `BufferTimeoutWithBackpressureSubscriber` computes:

```java
prefetch = batchSize << 2;      // maxSize * 4
replenishMark = batchSize << 1; // maxSize * 2
```

For large `maxSize` (e.g. `Integer.MAX_VALUE`, or anything above `Integer.MAX_VALUE >> 2`) those shifts overflow and become **negative**.

Downstream demand then never turns into an upstream request (`outstanding < replenishMark` stays false when `replenishMark` is negative), so the sequence just hangs.

The classic (non-fair) path already special-cases `Integer.MAX_VALUE`; only the fair path introduced in #3332 had this gap.

### Fix

Compute with `long` and saturate at `Integer.MAX_VALUE` (unbounded prefetch / queue):

```java
this.prefetch = (int) Math.min((long) batchSize << 2, Integer.MAX_VALUE);
this.replenishMark = (int) Math.min((long) batchSize << 1, Integer.MAX_VALUE);
```

### Tests

- Prefetch capacity at the overflow boundary, for `Integer.MAX_VALUE`, and for a still-safe batch size
- End-to-end: `bufferTimeout(Integer.MAX_VALUE, …, true)` requests upstream and delivers on timeout (would hang before)

Verified the regressions fail without the fix and pass with it.