### PR TITLE
Add UndecoratedRunnable to skip onSchedule decoration

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1018,14 +1018,16 @@ public abstract class Schedulers {
 	}
 
 	/**
-	 * Applies the hooks registered with {@link Schedulers#onScheduleHook(String, Function)}.
+	 * Applies the hooks registered with {@link Schedulers#onScheduleHook(String, Function)},
+	 * unless the {@link Runnable} implements {@link UndecoratedRunnable}.
 	 *
 	 * @param runnable a {@link Runnable} submitted to a {@link Scheduler}
-	 * @return decorated {@link Runnable} if any hook is registered, the original otherwise.
+	 * @return decorated {@link Runnable} if any hook is registered and the task is not an
+	 * {@link UndecoratedRunnable}, the original otherwise.
 	 */
 	public static Runnable onSchedule(Runnable runnable) {
 		Function<Runnable, Runnable> hook = onScheduleHook;
-		if (hook != null) {
+		if (hook != null && !(runnable instanceof UndecoratedRunnable)) {
 			return hook.apply(runnable);
 		}
 		else {

--- a/reactor-core/src/main/java/reactor/core/scheduler/UndecoratedRunnable.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/UndecoratedRunnable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.core.scheduler;
+
+/**
+ * A marker interface for {@link Runnable} tasks that must be submitted to a
+ * {@link Scheduler} without the decoration registered via
+ * {@link Schedulers#onScheduleHook(String, java.util.function.Function)}:
+ * {@link Schedulers#onSchedule(Runnable)} returns such tasks as-is.
+ *
+ * <p>Intended for library-internal, self-rescheduling maintenance tasks (for example
+ * background resource eviction) that never execute user code. Decorating such a task
+ * with a hook that captures caller state (such as the context-capture hook installed by
+ * {@link reactor.core.publisher.Hooks#enableAutomaticContextPropagation()}) stores the
+ * scheduling caller's {@code ThreadLocal} state (typically request-scoped, because such
+ * resources are usually created lazily on request processing threads) in the pending
+ * task. A task that re-schedules itself from within its own execution then re-captures
+ * that state on every reschedule, retaining the caller's object graph for the lifetime
+ * of the resource instead of the lifetime of the request.
+ *
+ * <p>User-facing tasks should not implement this interface: skipping decoration also
+ * skips user-registered hooks such as MDC propagation.
+ *
+ * @since 3.8.7
+ */
+public interface UndecoratedRunnable extends Runnable {
+}

--- a/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
+++ b/reactor-core/src/test/java/reactor/core/scheduler/SchedulersHooksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,6 +116,32 @@ public class SchedulersHooksTest {
 	public void onScheduleIgnoresUnknownRemovals() {
 		assertThatCode(() -> Schedulers.resetOnScheduleHook("k1"))
 				.doesNotThrowAnyException();
+	}
+
+	@Test
+	public void onScheduleReturnsUndecoratedRunnableAsIs() {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+
+		Runnable plain = () -> { };
+		UndecoratedRunnable undecorated = () -> { };
+
+		assertThat(Schedulers.onSchedule(plain)).as("plain task decorated").isNotSameAs(plain);
+		assertThat(Schedulers.onSchedule(undecorated)).as("undecorated task returned as-is").isSameAs(undecorated);
+	}
+
+	@ParameterizedTestWithName
+	@MethodSource("schedulers")
+	public void onScheduleSkipsUndecoratedRunnable(Supplier<Scheduler> schedulerType) throws Exception {
+		AtomicInteger tracker = new AtomicInteger();
+		Schedulers.onScheduleHook("k1", new TrackingDecorator(tracker, 1));
+
+		CountDownLatch latch = new CountDownLatch(1);
+		UndecoratedRunnable task = latch::countDown;
+		afterTest.autoDispose(schedulerType.get()).schedule(task);
+		latch.await(5, TimeUnit.SECONDS);
+
+		assertThat(tracker).as("hook not applied to UndecoratedRunnable").hasValue(0);
 	}
 
 	@ParameterizedTestWithName


### PR DESCRIPTION
## What

Adds `UndecoratedRunnable`, a marker interface for `Runnable` tasks that must be
submitted to a `Scheduler` without the decoration registered via
`Schedulers.onScheduleHook(String, Function)`. `Schedulers.onSchedule(Runnable)`
now returns such tasks as-is.

## Why

Library-internal, self-rescheduling maintenance tasks (resource eviction and the
like) never execute user code, yet they currently receive the same task decoration
as user tasks. With `Hooks.enableAutomaticContextPropagation()` enabled, that
decoration captures the scheduling caller's `ThreadLocal` state into the pending
task; because such tasks re-schedule themselves from inside the restored snapshot
scope, the captured request-scoped state is retained for the lifetime of the
resource (437MB observed in production — see #4338 and reactor/reactor-netty#4299).

There is no way to opt out today: every asynchronous `Scheduler` built via the
`Schedulers` factory methods funnels tasks through `Schedulers.onSchedule(...)`.
reactor-netty had to hand-write a bypassing `Scheduler` in reactor/reactor-netty#4300;
reactor-pool's eviction task has the same shape and still affects direct
reactor-pool users. This marker gives libraries a first-class opt-out while
keeping the standard schedulers, including schedulers supplied by the user.

The name mirrors the existing `NonBlocking` thread marker in the same package.
Happy to rename or reshape the API if you prefer a different form.

## Changes

- New `reactor.core.scheduler.UndecoratedRunnable` marker interface (no methods).
- `Schedulers.onSchedule(Runnable)` skips hook application for tasks implementing it.
  The added `instanceof` sits behind the existing `hook != null` short-circuit, so it
  only executes when a hook is registered, and is negligible next to the wrapper
  allocation it avoids (the class already type-checks similarly with
  `Thread instanceof NonBlocking`).
- Tests in `SchedulersHooksTest`: a direct `onSchedule` unit test and a
  parameterized end-to-end test across PARALLEL / BOUNDED_ELASTIC / SINGLE /
  EXECUTOR_SERVICE / EXECUTOR verifying the hook is not applied to marked tasks.

User-facing tasks should not implement the marker (documented in the javadoc):
skipping decoration also skips user-registered hooks such as MDC propagation.

Fixes #4338.