### PR TITLE
Ignore MonoSingle empty completion after cancellation

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ final class MonoSingle<T> extends MonoFromFluxOperator<T, T> {
 			if (c == 0) {
 
 				if (completeOnEmpty) {
-					actual().onComplete();
+					complete();
 					return;
 				}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSingleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,17 @@ package reactor.core.publisher;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
 import reactor.core.Fuseable;
 import reactor.core.Scannable;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 import reactor.test.subscriber.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.*;
@@ -443,6 +446,28 @@ public class MonoSingleTest {
 		                        .hide()
 		                        .singleOrEmpty())
 		            .verifyError(IndexOutOfBoundsException.class);
+	}
+
+	@Test
+	public void emptyCompletionAfterCancellationIsIgnored() {
+		TestPublisher<Integer> source =
+				TestPublisher.createNoncompliant(TestPublisher.Violation.DEFER_CANCELLATION);
+		AtomicBoolean fallbackSubscribed = new AtomicBoolean();
+
+		Disposable subscription =
+				source.flux()
+				      .singleOrEmpty()
+				      .switchIfEmpty(
+						      Mono.defer(() -> {
+							      fallbackSubscribed.set(true);
+							      return Mono.empty();
+						      }))
+				      .subscribe();
+
+		subscription.dispose();
+		source.complete();
+
+		assertThat(fallbackSubscribed).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
## Description

`MonoSingle.SingleSubscriber.onComplete()` completed empty sources with a direct `actual().onComplete()` call when `completeOnEmpty` was enabled (`singleOrEmpty()`). That path bypassed the cancellation-aware completion state in `MonoInnerProducerBase`, so an empty completion racing with cancel could still be delivered downstream.

In practice this could activate `switchIfEmpty` after dispose and trigger subscription-time side effects or `onErrorDropped` when the fallback failed.

## Fix

Use `complete()` for the empty `completeOnEmpty` path so completion is coordinated with cancellation atomically, matching the single-item completion path in the same class.

## Verification

- `./gradlew :reactor-core:test --tests reactor.core.publisher.MonoSingleTest --no-daemon` (43/43)
- `./gradlew :reactor-core:test --tests reactor.core.publisher.MonoSingle* --tests reactor.core.publisher.FluxSwitchIfEmptyTest --no-daemon` (104/104)
- `./gradlew spotlessCheck --no-daemon`

Fixes #4330.