### PR TITLE
Fix groupBy cancellation signal loss

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxGroupBy.java
@@ -121,6 +121,8 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 				AtomicLongFieldUpdater.newUpdater(GroupByMain.class, "requested");
 
 		volatile boolean done;
+		volatile boolean completing;
+		volatile boolean terminated;
 
 		volatile @Nullable Throwable error;
 
@@ -194,24 +196,58 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 				return;
 			}
 
-			UnicastGroupedFlux<K, V> g = groupMap.get(key);
+			onNext(key, value, false);
+		}
 
-			if (g == null) {
-				// if the main is cancelled, don't create new groups
-				if (cancelled == 0) {
-					Queue<V> q = groupQueueSupplier.get();
+		void onNext(K key, V value, boolean allowAfterSourceComplete) {
+			for (;;) {
+				UnicastGroupedFlux<K, V> g = groupMap.get(key);
 
-					GROUP_COUNT.getAndIncrement(this);
-					g = new UnicastGroupedFlux<>(key, q, this, prefetch);
-					g.onNext(value);
-					groupMap.put(key, g);
+				if (g == null) {
+					boolean newGroup = false;
+					synchronized (groupMap) {
+						g = groupMap.get(key);
+						// if the main is cancelled or terminated, don't create new groups
+						if (g == null && cancelled == 0 &&
+								(!done || allowAfterSourceComplete && !terminated)) {
+							Queue<V> q = groupQueueSupplier.get();
 
-					queue.offer(g);
-					drain();
+							GROUP_COUNT.getAndIncrement(this);
+							g = new UnicastGroupedFlux<>(key, q, this, prefetch);
+							g.onNext(value);
+							groupMap.put(key, g);
+
+							queue.offer(g);
+							if (done) {
+								g.onComplete();
+							}
+							newGroup = true;
+						}
+					}
+					if (newGroup) {
+						drain();
+						break;
+					}
+					if (g == null) {
+						break;
+					}
 				}
+				if (g.onNext(value)) {
+					break;
+				}
+
+				// cancellation won before the value was accepted, retry with a new group
+				groupMap.remove(key, g);
 			}
-			else {
-				g.onNext(value);
+		}
+
+		void onGroupCancelled(K key, @Nullable V value, Queue<V> groupQueue) {
+			if (value != null) {
+				onNext(key, value, true);
+			}
+			V queuedValue;
+			while ((queuedValue = groupQueue.poll()) != null) {
+				onNext(key, queuedValue, true);
 			}
 		}
 
@@ -231,11 +267,12 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			if(done){
 				return;
 			}
+			done = true;
+			completing = true;
 			for (UnicastGroupedFlux<K, V> g : groupMap.values()) {
 				g.onComplete();
 			}
-			groupMap.clear();
-			done = true;
+			completing = false;
 			drain();
 		}
 
@@ -267,6 +304,7 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			for (UnicastGroupedFlux<K, V> g : groupMap.values()) {
 				g.onError(e);
 			}
+			terminated = true;
 			actual.onError(e);
 			groupMap.clear();
 		}
@@ -303,20 +341,41 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			}
 		}
 
-		void groupTerminated(K key) {
+		void groupTerminated(K key, UnicastGroupedFlux<K, V> group) {
 			if (groupCount == 0) {
 				return;
 			}
-			groupMap.remove(key);
+			groupMap.remove(key, group);
 			int groupRemaining = GROUP_COUNT.decrementAndGet(this);
 			if (groupRemaining == 0) {
 				s.cancel();
 			}
-			else if (groupRemaining == 1) {
+			else if (groupRemaining == 1 && !done) {
 				//there is an "extra" group count for the global cancellation, so the operator as a whole is still active
 				//we want at least one more group
 				s.request(Operators.unboundedOrPrefetch(prefetch));
 			}
+			if (done) {
+				drain();
+			}
+		}
+
+		boolean hasActiveGroups() {
+			for (UnicastGroupedFlux<K, V> group : groupMap.values()) {
+				if (group.actual != null) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		void signalComplete(Subscriber<?> a) {
+			terminated = true;
+			for (UnicastGroupedFlux<K, V> group : groupMap.values()) {
+				group.doTerminate();
+			}
+			groupMap.clear();
+			a.onComplete();
 		}
 
 		void drain() {
@@ -349,13 +408,13 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 
 				a.onNext(null);
 
-				if (d) {
+				if (d && !completing && !hasActiveGroups()) {
 					Throwable ex = error;
 					if (ex != null) {
 						signalAsyncError();
 					}
 					else {
-						a.onComplete();
+						signalComplete(a);
 					}
 					return;
 				}
@@ -422,15 +481,15 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 				boolean empty,
 				Subscriber<?> a,
 				Queue<GroupedFlux<K, V>> q) {
-			if (d) {
+			if (d && !completing) {
 				Throwable e = error;
 				if (e != null && e != Exceptions.TERMINATED) {
 					q.clear();
 					signalAsyncError();
 					return true;
 				}
-				else if (empty) {
-					a.onComplete();
+				else if (empty && !hasActiveGroups()) {
+					signalComplete(a);
 					return true;
 				}
 			}
@@ -485,7 +544,6 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		final Queue<V> queue;
 
 		volatile @Nullable GroupByMain<?, K, V> parent;
-
 		@SuppressWarnings("rawtypes")
 		static final AtomicReferenceFieldUpdater<UnicastGroupedFlux, @Nullable GroupByMain> PARENT =
 				AtomicReferenceFieldUpdater.newUpdater(UnicastGroupedFlux.class,
@@ -540,7 +598,7 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		void doTerminate() {
 			GroupByMain<?, K, V> r = parent;
 			if (r != null && PARENT.compareAndSet(this, r, null)) {
-				r.groupTerminated(key);
+				r.groupTerminated(key, this);
 			}
 		}
 
@@ -560,22 +618,26 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 					V t = q.poll();
 					boolean empty = t == null;
 
-					if (checkTerminated(d, empty, a, q)) {
-						return;
-					}
+					synchronized (this) {
+						if (checkTerminated(d, empty, t, a, q)) {
+							return;
+						}
 
-					if (empty) {
-						break;
-					}
+						if (empty) {
+							break;
+						}
 
-					a.onNext(t);
+						a.onNext(t);
+					}
 
 					e++;
 				}
 
 				if (r == e) {
-					if (checkTerminated(done, q.isEmpty(), a, q)) {
-						return;
+					synchronized (this) {
+						if (checkTerminated(done, q.isEmpty(), null, a, q)) {
+							return;
+						}
 					}
 				}
 
@@ -611,28 +673,30 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			final Queue<V> q = queue;
 
 			for (; ; ) {
-
-				if (cancelled) {
-					q.clear();
-					actual = null;
-					return;
-				}
-
-				boolean d = done;
-
-				a.onNext(null);
-
-				if (d) {
-					actual = null;
-
-					Throwable ex = error;
-					if (ex != null) {
-						a.onError(ex);
+				synchronized (this) {
+					if (cancelled) {
+						handoffCancelledValues(null, q);
+						actual = null;
+						return;
 					}
-					else {
-						a.onComplete();
+
+					boolean d = done;
+
+					a.onNext(null);
+
+					if (d) {
+						actual = null;
+
+						Throwable ex = error;
+						if (ex != null) {
+							a.onError(ex);
+						}
+						else {
+							a.onComplete();
+						}
+						doTerminate();
+						return;
 					}
-					return;
 				}
 
 				missed = WIP.addAndGet(this, -missed);
@@ -658,9 +722,13 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 			}
 		}
 
-		boolean checkTerminated(boolean d, boolean empty, Subscriber<?> a, Queue<?> q) {
+		boolean checkTerminated(boolean d,
+				boolean empty,
+				@Nullable V value,
+				Subscriber<?> a,
+				Queue<?> q) {
 			if (cancelled) {
-				q.clear();
+				handoffCancelledValues(value, queue);
 				actual = null;
 				return true;
 			}
@@ -673,6 +741,7 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 				else {
 					a.onComplete();
 				}
+				doTerminate();
 				return true;
 			}
 
@@ -680,27 +749,31 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		}
 
 		@SuppressWarnings("DataFlowIssue") // fusion passes nulls via onNext
-		public void onNext(V t) {
-			CoreSubscriber<? super V> a = actual;
+		public boolean onNext(V t) {
+			CoreSubscriber<? super V> a;
+			boolean offered;
+			synchronized (this) {
+				if (cancelled || done) {
+					return false;
+				}
 
-			if (!queue.offer(t)) {
+				a = actual;
+				offered = queue.offer(t);
+			}
+			if (!offered) {
 				onError(Operators.onOperatorError(this, Exceptions.failWithOverflow(Exceptions.BACKPRESSURE_ERROR_QUEUE_FULL), t,
 						a != null ? a.currentContext() : Context.empty()));
-				return;
+				return true;
 			}
-			if (outputFused) {
-				if (a != null) {
-					a.onNext(null); // in op-fusion, onNext(null) is the indicator of more data
-				}
-			}
-			else {
-				drain();
-			}
+			drain();
+			return true;
 		}
 
 		public void onError(Throwable t) {
-			error = t;
-			done = true;
+			synchronized (this) {
+				error = t;
+				done = true;
+			}
 
 			doTerminate();
 
@@ -708,10 +781,9 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 		}
 
 		public void onComplete() {
-			done = true;
-
-			doTerminate();
-
+			synchronized (this) {
+				done = true;
+			}
 			drain();
 		}
 
@@ -738,18 +810,27 @@ final class FluxGroupBy<T, K, V> extends InternalFluxOperator<T, GroupedFlux<K, 
 
 		@Override
 		public void cancel() {
-			if (cancelled) {
-				return;
-			}
-			cancelled = true;
-
-			doTerminate();
-
-			if (!outputFused) {
-				if (WIP.getAndIncrement(this) == 0) {
-					queue.clear();
+			synchronized (this) {
+				if (cancelled) {
+					return;
 				}
+				cancelled = true;
 			}
+
+			if (WIP.getAndIncrement(this) == 0) {
+				handoffCancelledValues(null, queue);
+			}
+		}
+
+		void handoffCancelledValues(@Nullable V value, Queue<V> q) {
+			GroupByMain<?, K, V> main = parent;
+			if (main != null) {
+				main.onGroupCancelled(key, value, q);
+			}
+			else {
+				q.clear();
+			}
+			doTerminate();
 		}
 
 		@Override

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxGroupByTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,16 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.AbstractQueue;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -46,6 +51,78 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class FluxGroupByTest extends
                              FluxOperatorTest<String, GroupedFlux<Integer, String>> {
+
+	@Test
+	@Timeout(10)
+	// see https://github.com/reactor/reactor-core/issues/2352
+	void valuePolledWhenGroupCancelledIsRegrouped() throws InterruptedException {
+		BlockingPollQueue<Integer> groupQueue = new BlockingPollQueue<>();
+		AtomicInteger suppliedQueues = new AtomicInteger();
+		AssertSubscriber<GroupedFlux<Integer, Integer>> groupSubscriber = AssertSubscriber.create();
+		FluxGroupBy.GroupByMain<Integer, Integer, Integer> main = new FluxGroupBy.GroupByMain<>(
+				groupSubscriber,
+				Queues.<GroupedFlux<Integer, Integer>>unbounded().get(),
+				() -> suppliedQueues.getAndIncrement() == 0 ? groupQueue : Queues.<Integer>unbounded().get(),
+				Queues.SMALL_BUFFER_SIZE,
+				ignored -> 0,
+				Function.identity());
+		main.onSubscribe(Operators.emptySubscription());
+
+		main.onNext(1);
+
+		FluxGroupBy.UnicastGroupedFlux<Integer, Integer> group =
+				(FluxGroupBy.UnicastGroupedFlux<Integer, Integer>) groupSubscriber.values().get(0);
+		AssertSubscriber<Integer> valueSubscriber = AssertSubscriber.create(0);
+		group.subscribe(valueSubscriber);
+
+		Thread request = new Thread(() -> valueSubscriber.request(1));
+		try {
+			request.start();
+			assertThat(groupQueue.pollStarted.await(5, TimeUnit.SECONDS)).isTrue();
+			group.cancel();
+		}
+		finally {
+			groupQueue.continuePoll.countDown();
+			request.join();
+		}
+
+		valueSubscriber.assertNoValues();
+		groupSubscriber.assertValueCount(2);
+
+		AssertSubscriber<Integer> replacementSubscriber = AssertSubscriber.create();
+		groupSubscriber.values().get(1).subscribe(replacementSubscriber);
+		replacementSubscriber.assertValues(1);
+	}
+
+	@Test
+	void gh2352SimplifiedReproducer() {
+		Long count = Flux.range(0, 100)
+		                 .groupBy(i -> (i / 2) * 2, 42)
+		                 .flatMap(group -> group.take(1), 2)
+		                 .publishOn(Schedulers.parallel(), 2)
+		                 .count()
+		                 .block(Duration.ofSeconds(5));
+
+		assertThat(count).isEqualTo(100);
+	}
+
+	@Test
+	@Timeout(10)
+	void gh2352TimedGroupCancellation() {
+		AtomicLong nextValue = new AtomicLong();
+		AtomicLong upstream = new AtomicLong();
+		AtomicLong downstream = new AtomicLong();
+
+		Flux.<Long>generate(sink -> sink.next(nextValue.getAndIncrement()))
+		    .take(Duration.ofMillis(500))
+		    .doOnNext(ignored -> upstream.incrementAndGet())
+		    .groupBy(value -> value % 8)
+		    .flatMap(group -> group.take(Duration.ofMillis(5)), 8)
+		    .doOnNext(ignored -> downstream.incrementAndGet())
+		    .blockLast(Duration.ofSeconds(5));
+
+		assertThat(downstream).hasValue(upstream.get());
+	}
 
 	@Test
 	// see https://github.com/reactor/reactor-core/issues/3554
@@ -1007,5 +1084,53 @@ public class FluxGroupByTest extends
 				)
 				.then()
 				.block();
+	}
+
+	static final class BlockingPollQueue<T> extends AbstractQueue<T> {
+
+		final Queue<T> delegate = Queues.<T>unbounded().get();
+		final CountDownLatch pollStarted = new CountDownLatch(1);
+		final CountDownLatch continuePoll = new CountDownLatch(1);
+
+		@Override
+		public boolean offer(T value) {
+			return delegate.offer(value);
+		}
+
+		@Override
+		public T poll() {
+			T value = delegate.poll();
+			if (value != null) {
+				pollStarted.countDown();
+				try {
+					continuePoll.await();
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(e);
+				}
+			}
+			return value;
+		}
+
+		@Override
+		public T peek() {
+			return delegate.peek();
+		}
+
+		@Override
+		public Iterator<T> iterator() {
+			return delegate.iterator();
+		}
+
+		@Override
+		public int size() {
+			return delegate.size();
+		}
+
+		@Override
+		public void clear() {
+			delegate.clear();
+		}
 	}
 }


### PR DESCRIPTION
Cancelled GroupedFlux instances no longer silently lose values that were accepted or dequeued while cancellation raced with delivery. Buffered values are handed back to GroupByMain and routed into a replacement group, preserving signal counts without scheduler isolation.

A cancellation could previously win after GroupByMain selected a group, or after the inner drain polled a value, and then clear the queue or complete downstream. This change keeps completed groups attached long enough to hand off buffered values, makes group removal identity-aware so an old group cannot remove its replacement, serializes queue mutation with cancellation, and keeps dequeue-and-delivery atomic. Outer completion waits for subscribed groups to finish any pending handoff.

Checks:
- deterministic cancellation-after-poll regression test
- maintainer simplified range/groupBy/take(1) reproducer
- timed multi-threaded group cancellation reproducer
- high-cardinality multi-scheduler stress scenario (5 consecutive runs)
- ./gradlew :reactor-core:test spotlessCheck (10,005 tests; 9,595 passed, 410 skipped)

Fixes #2352.