### PR TITLE
Don't discard concatMap value that was already emitted

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxConcatMap.java
@@ -467,7 +467,11 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 
 		final CoreSubscriber<? super T> actual;
 		final T                     value;
-		boolean once;
+
+		volatile int once;
+		@SuppressWarnings("rawtypes")
+		static final AtomicIntegerFieldUpdater<WeakScalarSubscription> ONCE =
+				AtomicIntegerFieldUpdater.newUpdater(WeakScalarSubscription.class, "once");
 
 		WeakScalarSubscription(T value, CoreSubscriber<? super T> actual) {
 			this.value = value;
@@ -476,8 +480,7 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 
 		@Override
 		public void request(long n) {
-			if (n > 0 && !once) {
-				once = true;
+			if (n > 0 && ONCE.compareAndSet(this, 0, 1)) {
 				Subscriber<? super T> a = actual;
 				a.onNext(value);
 				a.onComplete();
@@ -486,7 +489,11 @@ final class FluxConcatMap<T, R> extends InternalFluxOperator<T, R> {
 
 		@Override
 		public void cancel() {
-			Operators.onDiscard(value, actual.currentContext());
+			// only discard the value if it hasn't been emitted yet, otherwise the
+			// downstream owns it (see Operators.ScalarSubscription#cancel)
+			if (ONCE.compareAndSet(this, 0, 2)) {
+				Operators.onDiscard(value, actual.currentContext());
+			}
 		}
 	}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/AbstractFluxConcatMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,6 +46,24 @@ public abstract class AbstractFluxConcatMapTest extends FluxOperatorTest<String,
 			.shouldHitDropErrorHookAfterTerminate(false)
 			.prefetch(testBasePrefetchValue() == 0 ? -1 : testBasePrefetchValue())
 			.producerError(new RuntimeException("AbstractFluxConcatMapTest"));
+	}
+
+	@Test
+	void scalarInnerValueIsNotDiscardedAfterBeingEmitted() {
+		List<Object> discarded = new ArrayList<>();
+
+		// the source doesn't complete, so that cancellation happens while the scalar
+		// inner subscription that has already emitted its value is still current
+		Flux<Integer> flux = Flux.concat(Flux.just(1), Flux.never())
+				.concatMap(Mono::just, testBasePrefetchValue())
+				.doOnDiscard(Object.class, discarded::add);
+
+		StepVerifier.create(flux, 1)
+				.expectNext(1)
+				.thenCancel()
+				.verify();
+
+		assertThat(discarded).as("discarded after being emitted").isEmpty();
 	}
 
 	@Override


### PR DESCRIPTION
`Flux.concatMap` (and `concatMapDelayError`) can route a value that was **already emitted** to the discard handler when the subscription is cancelled. For reference-counted values this is a use-after-free: a `doOnDiscard` hook releases a buffer that the downstream consumer still owns and is reading.

`WeakScalarSubscription`, which backs scalar (`Callable`) inners such as `Mono.just(...)` in both `FluxConcatMap` and `FluxConcatMapNoPrefetch`, guards emission with `once` but not the discard:

```java
public void request(long n) {
    if (n > 0 && !once) { once = true; a.onNext(value); a.onComplete(); }
}

public void cancel() {
    Operators.onDiscard(value, actual.currentContext()); // no once check
}
```

So `request()` → `onNext(value)` → later `cancel()` discards the very same value. This PR guards the discard with the same `once` state, mirroring `Operators.ScalarSubscription#cancel()`, and turns the flag into a `volatile int` updated by CAS so a `cancel()` racing with `request()` from another thread resolves to exactly one of emit or discard.

How it showed up in production: a WebFlux handler consuming `Flux<PartEvent>` registers `doOnDiscard` that releases `PartEvent#content()` (which `PartEvent` javadoc requires subscribers to release). Spring's `PartEventHttpMessageReader` builds events with `bodyTokens.concatMap(token -> Mono.just(event))`, so every cancelled upload (client disconnect, timeout, failing part) released a `DataBuffer` that was already handed to the consumer, producing `IllegalReferenceCountException: refCnt: 0` and returning HTTP 500s.

The new test in `AbstractFluxConcatMapTest` therefore runs for both the prefetch (`FluxConcatMapTest`) and no-prefetch (`FluxConcatMapNoPrefetchTest`) variants. Without the fix both fail with `Expecting empty but was: [1]`; with the fix applied they pass.

`:reactor-core:test --tests "reactor.core.publisher.*Concat*" --tests "reactor.core.publisher.OperatorsTest" --tests "reactor.core.publisher.FluxFlatMapTest"`, `spotlessCheck` and `:reactor-core:japicmp` pass locally.
