### PR TITLE
Avoid a second key scan in Context getOrDefault

### DIFF
--- a/reactor-core/src/main/java/reactor/util/context/Context1.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context1.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 final class Context1 implements CoreContext {
 
 	final Object key;
@@ -66,6 +68,15 @@ final class Context1 implements CoreContext {
 			return (T)this.value;
 		}
 		throw new NoSuchElementException("Context does not contain key: " + key);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getOrDefault(Object key, @Nullable T defaultValue) {
+		if (this.key.equals(key)) {
+			return (T) this.value;
+		}
+		return defaultValue;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context2.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context2.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 final class Context2 implements CoreContext {
 
 	final Object key1;
@@ -86,6 +88,18 @@ final class Context2 implements CoreContext {
 			return (T)this.value2;
 		}
 		throw new NoSuchElementException("Context does not contain key: "+key);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getOrDefault(Object key, @Nullable T defaultValue) {
+		if (this.key1.equals(key)) {
+			return (T) this.value1;
+		}
+		if (this.key2.equals(key)) {
+			return (T) this.value2;
+		}
+		return defaultValue;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context3.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context3.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 final class Context3 implements CoreContext {
 
 	final Object key1;
@@ -106,6 +108,21 @@ final class Context3 implements CoreContext {
 			return (T)this.value3;
 		}
 		throw new NoSuchElementException("Context does not contain key: "+key);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getOrDefault(Object key, @Nullable T defaultValue) {
+		if (this.key1.equals(key)) {
+			return (T) this.value1;
+		}
+		if (this.key2.equals(key)) {
+			return (T) this.value2;
+		}
+		if (this.key3.equals(key)) {
+			return (T) this.value3;
+		}
+		return defaultValue;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context4.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context4.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 final class Context4 implements CoreContext {
 
 	/**
@@ -146,6 +148,24 @@ final class Context4 implements CoreContext {
 			return (T)this.value4;
 		}
 		throw new NoSuchElementException("Context does not contain key: "+key);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getOrDefault(Object key, @Nullable T defaultValue) {
+		if (this.key1.equals(key)) {
+			return (T) this.value1;
+		}
+		if (this.key2.equals(key)) {
+			return (T) this.value2;
+		}
+		if (this.key3.equals(key)) {
+			return (T) this.value3;
+		}
+		if (this.key4.equals(key)) {
+			return (T) this.value4;
+		}
+		return defaultValue;
 	}
 
 	@Override

--- a/reactor-core/src/main/java/reactor/util/context/Context5.java
+++ b/reactor-core/src/main/java/reactor/util/context/Context5.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 final class Context5 implements CoreContext {
 
 	final Object key1;
@@ -135,6 +137,27 @@ final class Context5 implements CoreContext {
 			return (T)this.value5;
 		}
 		throw new NoSuchElementException("Context does not contain key: "+key);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> @Nullable T getOrDefault(Object key, @Nullable T defaultValue) {
+		if (this.key1.equals(key)) {
+			return (T) this.value1;
+		}
+		if (this.key2.equals(key)) {
+			return (T) this.value2;
+		}
+		if (this.key3.equals(key)) {
+			return (T) this.value3;
+		}
+		if (this.key4.equals(key)) {
+			return (T) this.value4;
+		}
+		if (this.key5.equals(key)) {
+			return (T) this.value5;
+		}
+		return defaultValue;
 	}
 
 	@Override


### PR DESCRIPTION
## What

`ContextView.getOrDefault` is a `default` method implemented as `hasKey(key)` followed by `get(key)`. None of `Context1` … `Context5` override it, and each of those scans its keys linearly, so a successful lookup walks the key list twice. `Context1.get` calls `hasKey` itself, making that three passes.

This adds a single-scan `getOrDefault` override to the five flat implementations.

## Why it's worth doing

`getOrDefault` is not a cold path. It backs Micrometer's `ReactorContextAccessor`, and `Operators.onDiscard` / `onNextDropped` / `onOperatorError` all read through it. In a WebFlux application the operator chain, and therefore its `Context`, is rebuilt and read repeatedly per request.

## Measurements

JMH, JDK 21, `-f 2 -wi 3 -i 3`. Before and after differ only by these five overrides.

| Context size | `getOrDefault` before | `getOrDefault` after | delta | `get` (control) before → after |
|---|---|---|---|---|
| 1 | 0.757 ns | 0.754 ns | ~0 | 0.755 → 0.772 |
| 3 | 5.326 ns | 3.010 ns | **−2.32 ns (−43%)** | 3.018 → 3.014 |
| 5 | 10.297 ns | 5.450 ns | **−4.85 ns (−47%)** | 5.460 → 5.435 |
| 6 | 1.219 ns | 1.214 ns | ~0 | 1.207 → 1.211 |

Measurements were taken with the `Context` call sites made megamorphic — all six implementations driven through the same sites first. A benchmark that leaves one implementation at the call site lets C2 inline through it, which is not what the real callers present.


## Adjacent, not included

`ContextView.getOrEmpty` has the identical shape — `hasKey` then `get`, plus an `Optional` allocation on every hit, and is likewise not overridden by `Context1..5`. Left out to keep this PR to one thing; happy to follow up.
