### PR TITLE
Mark scheduler decorator removal nullable

### DIFF
--- a/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
+++ b/reactor-core/src/main/java/reactor/core/scheduler/Schedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -908,7 +908,7 @@ public abstract class Schedulers {
 	 * @see #addExecutorServiceDecorator(String, BiFunction)
 	 * @see #setExecutorServiceDecorator(String, BiFunction)
 	 */
-	public static BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> removeExecutorServiceDecorator(String key) {
+	public static @Nullable BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> removeExecutorServiceDecorator(String key) {
 		BiFunction<Scheduler, ScheduledExecutorService, ScheduledExecutorService> removed;
 		synchronized (DECORATORS) {
 			removed = DECORATORS.remove(key);


### PR DESCRIPTION
## Summary

Companion fix for #4364, targeting its exact Dependabot branch.

NullAway 0.14 recognizes that `Map.remove` can return `null`, while `removeExecutorServiceDecorator` was still declared non-null despite its documented and tested absent-key behavior. This marks that existing return contract `@Nullable`.

The copyright year update is the repository formatter's required change for the touched file. Runtime behavior is unchanged.

## Verification

- `./gradlew :reactor-core:compileJava --no-daemon` — passed with the repository's Java 25 compiler targeting Java 8.
- `./gradlew spotlessCheck -PspotlessFrom=origin/main japicmp --no-daemon` — passed both official preliminary gates.
- `./gradlew :reactor-core:test :reactor-core:java11Test :reactor-core:java21Test --no-daemon` — passed 30,067 tests across the Java 8, 11, and 21 lanes with 0 failures:
  - Java 8: 10,004 total; 9,594 passed; 410 skipped.
  - Java 11: 10,018 total; 9,608 passed; 410 skipped.
  - Java 21: 10,045 total; 9,648 passed; 397 skipped.
- `git diff --check` and complete one-file diff review — passed.

JAIPilot Remote was attempted, but its bounded Gradle mirror could not resolve `org.gradle.toolchains.foojay-resolver-convention:1.0.0` before repository configuration, so no remote build result is claimed.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
