### PR TITLE
Fix fair-backpressure bufferTimeout flushing a partial buffer on resumed demand

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -250,8 +250,9 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 						BufferTimeoutWithBackpressureSubscriber::incrementRequestIndex);
 				if (!hasWorkInProgress(previousState)) {
 					// If there was no demand before - try to fulfill the demand if there
-					// are buffered values.
-					drain(previouslyRequested == 0);
+					// are buffers ready to be delivered (full, timed out, or remaining
+					// after termination).
+					drain();
 				}
 			}
 		}
@@ -305,7 +306,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 			}
 
 			if (!hasWorkInProgress(previousState)) {
-				drain(false);
+				drain();
 			}
 		}
 
@@ -321,7 +322,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					BufferTimeoutWithBackpressureSubscriber::setTimedOut);
 
 			if (!hasWorkInProgress(previousState)) {
-				drain(false);
+				drain();
 			}
 		}
 
@@ -340,7 +341,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					BufferTimeoutWithBackpressureSubscriber::setTerminated);
 
 			if (!hasWorkInProgress(previousState)) {
-				drain(false);
+				drain();
 			}
 		}
 
@@ -357,7 +358,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					BufferTimeoutWithBackpressureSubscriber::setTerminated);
 
 			if (!hasWorkInProgress(previousState)) {
-				drain(false);
+				drain();
 			}
 		}
 
@@ -378,7 +379,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 					BufferTimeoutWithBackpressureSubscriber::setCancelled);
 
 			if (!hasWorkInProgress(previousState)) {
-				drain(false);
+				drain();
 			}
 		}
 
@@ -386,11 +387,8 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 		 * Drain the queue and perform any actions that result from the current state.
 		 * Ths method must only be called when the caller ensured exclusive access.
 		 * That means that it successfully indicated there's work by setting the WIP flag.
-		 *
-		 * @param resumeDemand {@code true} if the previous {@link #requested demand}
-		 *                                      value was 0.
 		 */
-		private void drain(boolean resumeDemand) {
+		private void drain() {
 			if (logger != null) {
 				trace(logger, "drain start");
 			}
@@ -410,8 +408,11 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 				} else {
 					long index = getIndex(currentState);
 					long currentRequest = this.requested;
+					// Flush only buffers that are actually due: full, timed out, or
+					// left over after upstream termination. Resumed demand alone must
+					// not flush a partial buffer ahead of its timeout.
 					boolean shouldFlush = currentRequest > 0
-							&& (resumeDemand || isTimedOut(currentState) || isTerminated(currentState) || index >= batchSize);
+							&& (isTimedOut(currentState) || isTerminated(currentState) || index >= batchSize);
 
 					int consumed = 0;
 					if (logger != null) {
@@ -428,10 +429,6 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 							if (logger != null) {
 								trace(logger, "flushed: " + consumedNow);
 							}
-							// We need to make sure that if work is added we clear the
-							// resumeDemand with which we entered the drain loop as the
-							// state is now different.
-							resumeDemand = false;
 							if (consumedNow == 0) {
 								break;
 							}

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutFairBackpressureTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxBufferTimeoutFairBackpressureTest.java
@@ -18,6 +18,7 @@ package reactor.core.publisher;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -535,6 +536,50 @@ public class FluxBufferTimeoutFairBackpressureTest {
 		            .assertNext(l -> assertThat(l).containsExactly(1))
 		            .expectErrorSatisfies(e -> assertThat(e).isInstanceOf(RejectedExecutionException.class))
 		            .verify();
+	}
+
+	@Test
+	void resumedDemandDoesNotFlushPartialBufferBeforeTimeout() throws InterruptedException {
+		Sinks.Many<Integer> sink = Sinks.many().unicast().onBackpressureBuffer();
+		List<List<Integer>> buffers = new CopyOnWriteArrayList<>();
+		AtomicReference<Subscription> sub = new AtomicReference<>();
+
+		sink.asFlux()
+		    .bufferTimeout(2, Duration.ofSeconds(10), true)
+		    .subscribe(new CoreSubscriber<List<Integer>>() {
+			    @Override
+			    public void onSubscribe(Subscription s) {
+				    sub.set(s);
+				    s.request(1);
+			    }
+
+			    @Override
+			    public void onNext(List<Integer> buffer) {
+				    buffers.add(buffer);
+			    }
+
+			    @Override
+			    public void onError(Throwable t) {
+			    }
+
+			    @Override
+			    public void onComplete() {
+			    }
+		    });
+
+		sink.tryEmitNext(0);
+		sink.tryEmitNext(1);
+		assertThat(buffers).containsExactly(Arrays.asList(0, 1));
+
+		// a new buffer starts with a single element while demand is 0
+		sink.tryEmitNext(2);
+		sub.get().request(1);
+		Thread.sleep(200);
+		// the open buffer is neither full nor timed out (10s timeout): resumed
+		// demand alone must not flush it early
+		assertThat(buffers).containsExactly(Arrays.asList(0, 1));
+
+		sub.get().cancel();
 	}
 
 	@Test


### PR DESCRIPTION
`bufferTimeout` with `fairBackpressure = true` flushed the currently open buffer whenever downstream demand resumed (a `request(n)` arriving while `requested == 0`), even though the buffer was neither full nor timed out — violating the documented "maxSize OR maxTime" contract that the non-fair variant honors.

This change removes the `resumeDemand` flush trigger from `BufferTimeoutWithBackpressureSubscriber.drain()` (and the now-unused parameter at its 6 call sites). The legitimate flush conditions remain covered by the sticky TIMEOUT/TERMINATED flags and `index >= batchSize`; residual-buffer delivery on later requests is guaranteed by the timer reschedule introduced in f185b9b.

Added a virtual-time regression test asserting the partial buffer is not delivered synchronously inside `request()` before its timeout; it fails on `main` and passes with the fix. `FluxBufferTimeoutFairBackpressureTest` passes 19/19 (including `downstreamNoReplenishButTimeout`, `bufferWithTimeoutAvoidingNegativeRequests`, `processesLargeDataset`, `backpressureSupported`), and `FluxBufferTimeoutTest` is green.

Fixes #4377