### PR TITLE
Add discard support to Mono.sequenceEqual

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Mono.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Mono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -802,6 +802,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/sequenceEqual.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued from
+	 * either source upon cancellation, error or when the sequences are detected to differ.
+	 *
 	 * @param source1 the first Publisher to compare
 	 * @param source2 the second Publisher to compare
 	 * @param <T> the type of items emitted by each Publisher
@@ -817,6 +820,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * equality function.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/sequenceEqual.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued from
+	 * either source upon cancellation, error or when the sequences are detected to differ.
 	 *
 	 * @param source1 the first Publisher to compare
 	 * @param source2 the second Publisher to compare
@@ -836,6 +842,9 @@ public abstract class Mono<T> implements CorePublisher<T> {
 	 * equality function.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/sequenceEqual.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued from
+	 * either source upon cancellation, error or when the sequences are detected to differ.
 	 *
 	 * @param source1 the first Publisher to compare
 	 * @param source2 the second Publisher to compare

--- a/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/MonoSequenceEqual.java
@@ -146,18 +146,26 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 				cancelInner(secondSubscriber);
 
 				if (WIP.getAndIncrement(this) == 0) {
-					firstSubscriber.queue.clear();
-					secondSubscriber.queue.clear();
+					discardCurrentValuesAndQueues();
 				}
 			}
 		}
 
-		void cancel(EqualSubscriber<T> s1, Queue<T> q1, EqualSubscriber<T> s2, Queue<T> q2) {
+		void cancelAndDiscard() {
 			cancelled = true;
-			cancelInner(s1);
-			q1.clear();
-			cancelInner(s2);
-			q2.clear();
+			cancelInner(firstSubscriber);
+			cancelInner(secondSubscriber);
+			discardCurrentValuesAndQueues();
+		}
+
+		void discardCurrentValuesAndQueues() {
+			Context ctx = actual.currentContext();
+			Operators.onDiscard(v1, ctx);
+			v1 = null;
+			Operators.onDiscardQueueWithClear(firstSubscriber.queue, ctx, null);
+			Operators.onDiscard(v2, ctx);
+			v2 = null;
+			Operators.onDiscardQueueWithClear(secondSubscriber.queue, ctx, null);
 		}
 
 		void cancelInner(EqualSubscriber<T> innerSubscriber) {
@@ -187,8 +195,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 				long r = 0L;
 				for (;;) {
 					if (cancelled) {
-						q1.clear();
-						q2.clear();
+						discardCurrentValuesAndQueues();
 						return;
 					}
 
@@ -197,7 +204,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 					if (d1) {
 						Throwable e = s1.error;
 						if (e != null) {
-							cancel(s1, q1, s2, q2);
+							cancelAndDiscard();
 
 							actual.onError(e);
 							return;
@@ -209,7 +216,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 					if (d2) {
 						Throwable e = s2.error;
 						if (e != null) {
-							cancel(s1, q1, s2, q2);
+							cancelAndDiscard();
 
 							actual.onError(e);
 							return;
@@ -232,7 +239,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 						return;
 					}
 					if ((d1 && d2) && (e1 != e2)) {
-						cancel(s1, q1, s2, q2);
+						cancelAndDiscard();
 
 						actual.onNext(false);
 						actual.onComplete();
@@ -246,7 +253,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 							c = comparer.test(v1, v2);
 						} catch (Throwable ex) {
 							Exceptions.throwIfFatal(ex);
-							cancel(s1, q1, s2, q2);
+							cancelAndDiscard();
 
 							actual.onError(Operators.onOperatorError(ex,
 									actual.currentContext()));
@@ -254,7 +261,7 @@ final class MonoSequenceEqual<T> extends Mono<Boolean> implements SourceProducer
 						}
 
 						if (!c) {
-							cancel(s1, q1, s2, q2);
+							cancelAndDiscard();
 
 							actual.onNext(false);
 							actual.onComplete();

--- a/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/MonoSequenceEqualTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package reactor.core.publisher;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -316,6 +318,53 @@ public class MonoSequenceEqualTest {
 		test.onError(new IllegalStateException("boom"));
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).isTrue();
 		assertThat(test.scan(Scannable.Attr.ERROR)).hasMessage("boom");
+	}
+
+	@Test
+	public void discardOnMismatch() {
+		StepVerifier.create(Mono.sequenceEqual(
+						Flux.just(1, 2, 3),
+						Flux.just(1, 7, 8)))
+		            .expectNext(Boolean.FALSE)
+		            .expectComplete()
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(2, 3, 7);
+	}
+
+	@Test
+	public void discardOnCancel() {
+		List<Object> discarded = new CopyOnWriteArrayList<>();
+		AtomicReference<Subscription> subscription = new AtomicReference<>();
+
+		Mono.sequenceEqual(
+				Flux.just(1, 2, 3).concatWith(Flux.never()),
+				Flux.never())
+		    .doOnDiscard(Object.class, discarded::add)
+		    .subscribe(new CoreSubscriber<Boolean>() {
+			    @Override
+			    public void onSubscribe(Subscription s) {
+				    subscription.set(s);
+				    s.request(Long.MAX_VALUE);
+			    }
+
+			    @Override
+			    public void onNext(Boolean b) {
+			    }
+
+			    @Override
+			    public void onError(Throwable t) {
+			    }
+
+			    @Override
+			    public void onComplete() {
+			    }
+		    });
+
+		// the first source's elements are all buffered awaiting elements from
+		// the second source, which never emits
+		subscription.get().cancel();
+
+		assertThat(discarded).containsExactly(1, 2, 3);
 	}
 
 	//TODO multithreaded race between cancel and onNext, between cancel and drain, source overflow, error dropping to hook


### PR DESCRIPTION
`MonoSequenceEqual` cleared both inner queues with a plain `queue.clear()` and silently dropped the held-but-uncompared `v1`/`v2` values on downstream cancel, source error, comparer throw, and the inequality short-circuit — no `Operators.onDiscard*` anywhere in the operator.

This change introduces `discardCurrentValuesAndQueues()` (discarding `v1`, `v2` and both queues via `Operators.onDiscard`/`onDiscardQueueWithClear`), invoked from `cancel()` under the WIP guard, from the drain-loop cancelled branch, and from the internal terminal path. Discard Support javadoc added to all three `Mono.sequenceEqual` overloads.

Two regression tests added (`discardOnCancel`, `discardOnMismatch`) — both fail on `main` with empty discard collections and pass with the fix; `MonoSequenceEqualTest` passes 23/23.

Fixes #4378