### PR TITLE
Add discard support to mergeSequential and flatMapSequential

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/Flux.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/Flux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1820,6 +1820,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialAsyncSources.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
+	 *
 	 * @param sources a {@link Publisher} of {@link Publisher} sources to merge
 	 * @param <T> the merged type
 	 *
@@ -1837,6 +1839,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * emitted values are merged into the final sequence in subscription order.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialAsyncSources.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
 	 *
 	 * @param sources a {@link Publisher} of {@link Publisher} sources to merge
 	 * @param prefetch the inner source request size
@@ -1859,6 +1863,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialAsyncSources.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation.
+	 *
 	 * @param sources a {@link Publisher} of {@link Publisher} sources to merge
 	 * @param prefetch the inner source request size
 	 * @param maxConcurrency the request produced to the main source thus limiting concurrent merge backlog
@@ -1878,6 +1884,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
+	 *
 	 * @param sources a number of {@link Publisher} sequences to merge
 	 * @param <I> the merged type
 	 *
@@ -1894,6 +1902,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * eagerly. Unlike merge, their emitted values are merged into the final sequence in subscription order.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
 	 *
 	 * @param prefetch the inner source request size
 	 * @param sources a number of {@link Publisher} sequences to merge
@@ -1915,6 +1925,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation.
+	 *
 	 * @param prefetch the inner source request size
 	 * @param sources a number of {@link Publisher} sequences to merge
 	 * @param <I> the merged type
@@ -1933,6 +1945,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
+	 *
 	 * @param sources an {@link Iterable} of {@link Publisher} sequences to merge
 	 * @param <I> the merged type
 	 *
@@ -1950,6 +1964,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * emitted values are merged into the final sequence in subscription order.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
 	 *
 	 * @param sources an {@link Iterable} of {@link Publisher} sequences to merge
 	 * @param maxConcurrency the request produced to the main source thus limiting concurrent merge backlog
@@ -1972,6 +1988,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * has been processed.
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/mergeSequentialVarSources.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation.
 	 *
 	 * @param sources an {@link Iterable} of {@link Publisher} sequences to merge
 	 * @param maxConcurrency the request produced to the main source thus limiting concurrent merge backlog
@@ -5765,6 +5783,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/flatMapSequential.svg" alt="">
 	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
+	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param <R> the merged output sequence type
 	 *
@@ -5804,6 +5824,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/flatMapSequentialWithConcurrency.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param maxConcurrency the maximum number of in-flight inner sequences
@@ -5847,6 +5869,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/flatMapSequentialWithConcurrencyAndPrefetch.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation or error.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param maxConcurrency the maximum number of in-flight inner sequences
@@ -5892,6 +5916,8 @@ public abstract class Flux<T> implements CorePublisher<T> {
 	 *
 	 * <p>
 	 * <img class="marble" src="doc-files/marbles/flatMapSequentialWithConcurrencyAndPrefetch.svg" alt="">
+	 *
+	 * <p><strong>Discard Support:</strong> This operator discards elements it internally queued for reordering upon cancellation.
 	 *
 	 * @param mapper the {@link Function} to transform input sequence into N sequences {@link Publisher}
 	 * @param maxConcurrency the maximum number of in-flight inner sequences

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxMergeSequential.java
@@ -610,6 +610,10 @@ final class FluxMergeSequential<T, R> extends InternalFluxOperator<T, R> {
 
 		void cancel() {
 			Operators.set(SUBSCRIPTION, this, Operators.cancelledSubscription());
+			Queue<R> q = queue;
+			if (q != null) {
+				Operators.onDiscardQueueWithClear(q, parent.currentContext(), null);
+			}
 		}
 
 		boolean isDone() {

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxMergeSequentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -64,6 +66,55 @@ public class FluxMergeSequentialTest {
 	public void before() {
 		ts = new AssertSubscriber<>();
 		tsBp = new AssertSubscriber<>(0L);
+	}
+
+	@Test
+	public void discardQueuedElementsOnCancel() {
+		List<Object> discarded = new CopyOnWriteArrayList<>();
+		List<Object> received = new ArrayList<>();
+		AtomicReference<Subscription> subscription = new AtomicReference<>();
+
+		Flux.mergeSequential(Flux.just(1, 2), Flux.just(3, 4))
+		    .doOnDiscard(Object.class, discarded::add)
+		    .subscribe(new CoreSubscriber<Integer>() {
+			    @Override
+			    public void onSubscribe(Subscription s) {
+				    subscription.set(s);
+				    s.request(1);
+			    }
+
+			    @Override
+			    public void onNext(Integer i) {
+				    received.add(i);
+			    }
+
+			    @Override
+			    public void onError(Throwable t) {
+			    }
+
+			    @Override
+			    public void onComplete() {
+			    }
+		    });
+
+		assertThat(received).containsExactly(1);
+
+		// elements 2 (in the current inner) and 3, 4 (in the queued-up second
+		// inner) are still buffered at this point
+		subscription.get().cancel();
+
+		assertThat(discarded).containsExactly(2, 3, 4);
+	}
+
+	@Test
+	public void discardQueuedElementsOnError() {
+		StepVerifier.create(Flux.mergeSequential(
+				            Flux.just(1, 2),
+				            Flux.just(3, 4).concatWith(Mono.error(new IllegalStateException("boom")))), 1)
+		            .expectNext(1)
+		            .expectErrorMessage("boom")
+		            .verifyThenAssertThat()
+		            .hasDiscardedExactly(2, 3, 4);
 	}
 
 	@Test


### PR DESCRIPTION
`MergeSequentialInner.cancel()` only swapped the subscription, so `cancelAll()` (used by downstream cancel and the `ErrorMode.IMMEDIATE` error paths) abandoned every element still queued for reordering without invoking the discard hook.

This change drains the inner queue through `Operators.onDiscardQueueWithClear(q, parent.currentContext(), null)` in `MergeSequentialInner.cancel()`, covering the current inner and all queued inners via `cancelAll` as well as the IMMEDIATE-error paths; delay-error modes still deliver buffered values first, unchanged. Discard Support javadoc added to the `mergeSequential*` and `flatMapSequential*` overloads (delayError variants documented as discarding on cancellation only).

Two regression tests added (`discardQueuedElementsOnCancel`, `discardQueuedElementsOnError`) — both fail on `main` with empty discard collections and pass with the fix; `FluxMergeSequentialTest` passes 59/59.

Fixes #4379