### PR TITLE
Add support for reproducible builds

### DIFF
--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -21,13 +21,18 @@ apply plugin: 'maven-publish'
 //we also conditionally apply artifactory and signing plugins below
 
 jar {
-	manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
+	manifest.attributes["Jdk-Build-Spec"] = "${System.getProperty("java.specification.version")}"
 	manifest.attributes["Implementation-Title"] = project.name
 	manifest.attributes["Implementation-Version"] = project.version
 	from("${rootDir}/docs/src/docs/dist") {
 		include "LICENSE"
 		into "META-INF"
 	}
+}
+
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
 }
 
 task sourcesJar(type: Jar) {

--- a/reactor-core-micrometer/build.gradle
+++ b/reactor-core-micrometer/build.gradle
@@ -33,7 +33,8 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-core-micrometer",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-core-micrometer",
-		"Bundle-Version" : "$osgiVersion"
+		"Bundle-Version" : "$osgiVersion",
+		"-noextraheaders" : "true"
 	]
 }
 

--- a/reactor-core/build.gradle
+++ b/reactor-core/build.gradle
@@ -40,7 +40,8 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-core",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-core",
-		"Bundle-Version" : "$osgiVersion"
+		"Bundle-Version" : "$osgiVersion",
+		"-noextraheaders" : "true"
 	]
 }
 

--- a/reactor-test/build.gradle
+++ b/reactor-test/build.gradle
@@ -32,7 +32,8 @@ ext {
 		].join(","),
 		"Bundle-Name" : "reactor-test",
 		"Bundle-SymbolicName" : "io.projectreactor.reactor-test",
-		"Bundle-Version" : "$osgiVersion"
+		"Bundle-Version" : "$osgiVersion",
+		"-noextraheaders" : "true"
 	]
 }
 


### PR DESCRIPTION
-noExtraHeaders in the bnd properties makes sure that non-deterministic headers like Created-By do not get added to the manifest.

<!-- 
Thanks for contributing to Project Reactor. Please review the following notes
about formatting your PR description.
-->

<!-- What changes from the user's perspective? -->


<!-- Next paragraph contains more technical details -->


<!-- The footer can contain the issue references: -->
<!-- See #{OPTIONAL_REF}. -->
<!-- Fixes #{ISSUE}. -->

<!--
The PR description will be used to craft a final squash merge commit
and the title will be used in release notes, so please keep them up-to-date.
More detailed description of the commit message convention:
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#black_nib-commit-message-convention
https://github.com/reactor/.github/blob/main/CONTRIBUTING.md#message-convention
-->
