### PR TITLE
Fix refCount leak on cancel during onSubscribe

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxRefCount.java
@@ -217,6 +217,7 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 				int previousState = this.state;
 
 				if (isCancelled(previousState)) {
+					connection.innerCancelled();
 					return;
 				}
 
@@ -300,10 +301,11 @@ final class FluxRefCount<T> extends Flux<T> implements Scannable, Fuseable {
 				return;
 			}
 
-			if (isMonitorSet(previousState)
-					&& STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
-				assert connection != null : "isMonitorSet check guarantees connection is not null";
-				connection.innerCancelled();
+			if (STATE.compareAndSet(this, previousState, previousState | CANCELLED_FLAG)) {
+				if (isMonitorSet(previousState)) {
+					assert connection != null : "isMonitorSet check guarantees connection is not null";
+					connection.innerCancelled();
+				}
 			}
 		}
 

--- a/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
+++ b/reactor-core/src/test/java/reactor/core/publisher/FluxRefCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2016-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -484,5 +484,28 @@ public class FluxRefCountTest {
 		assertThat(test.scan(Scannable.Attr.RUN_STYLE)).isSameAs(Scannable.Attr.RunStyle.SYNC);
 		assertThat(test.scan(Scannable.Attr.CANCELLED)).as("CANCELLED after cancel+onComplete").isTrue();
 		assertThat(test.scan(Scannable.Attr.TERMINATED)).as("TERMINATED after cancel+onComplete").isFalse();
+	}
+
+	@Test
+	public void refCountDisconnectsWhenSubscriberCancelsDuringOnSubscribe() {
+		Sinks.Many<Integer> source = Sinks.many().replay().latest();
+		source.emitNext(42, FAIL_FAST);
+
+		Flux<Integer> shared = source.asFlux()
+									 .replay(1)
+									 .refCount(1);
+
+		Disposable holder = shared.subscribe();
+		assertThat(source.currentSubscriberCount()).as("source connected").isPositive();
+
+		// replay(1) already holds 42, so next() receives it and cancels synchronously
+		// from inside setRefCountMonitor, before MONITOR_SET_FLAG has been set.
+		assertThat(shared.next().block()).isEqualTo(42);
+
+		holder.dispose();
+
+		assertThat(source.currentSubscriberCount())
+				.as("source disconnected once the ref count dropped to zero")
+				.isZero();
 	}
 }


### PR DESCRIPTION
Once every subscriber of a `replay(n).refCount(n)` flux has cancelled, the connection should be disposed and the upstream unsubscribed. Since 3.8.0 that stops happening when a subscriber cancels from inside `onSubscribe`, which is routine for `replay(1).refCount(1)`: the replayed value is delivered synchronously to a `next()` or `take(1)` subscriber, which cancels immediately. The connection is then never disposed and the upstream subscription leaks for the lifetime of the process.

`RefCountInner.cancel()` guards its CAS with `isMonitorSet`, so for a cancel arriving before `setRefCountMonitor` has set `MONITOR_SET_FLAG`, neither `CANCELLED_FLAG` nor `innerCancelled()` happens and the inner stays registered as a live subscriber.

That flag is there so the non-volatile `connection` field is safely published, not to gate the state transition: `onError` and `onComplete` already CAS unconditionally and let `isMonitorSet` guard only the notification. `cancel()` now does the same, and `setRefCountMonitor` calls `innerCancelled()` when it observes a cancel, mirroring the `upstreamFinished()` call it already makes when it observes a termination. The CAS stays the single gate, so `innerCancelled()` runs exactly once on every interleaving.

Guarding on `connection != null` instead would also make the reported case pass, but `connection` is a plain field, so that reintroduces the unsafe publication the flag exists to prevent.

Fixes #4387.
